### PR TITLE
Payload customization does not work for Rails metal controllers

### DIFF
--- a/lib/logstasher.rb
+++ b/lib/logstasher.rb
@@ -63,7 +63,7 @@ module LogStasher
   end
 
   def self.custom_fields
-    Thread.current[:logstasher_custom_fields] || []
+    Thread.current[:logstasher_custom_fields] ||= []
   end
 
   def self.custom_fields=(val)


### PR DESCRIPTION
When logstash is used with ActionController::Metal controllers it does not call LogStasher.add_custom_fields block so all event customizations we perform on our logstash events are not applied for our API controllers which are metal-based.

I've made a simple change in attached commit, which seems to be working fine for us in production, but unfortunately I wasn't able to test it properly with logstasher specs because AFAIU it would require some kind of integration testing with real application class, real controllers, etc.

I'm not sure if you could accept this patch as-is or maybe you could come up with a spec that would cover the changes properly w/o complicating the test suite with spec-rails, etc.
