### PR TITLE
Fixed spelling of "supress" in config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ In your Gemfile:
     # Enable the logstasher logs for the current environment
     config.logstasher.enabled = true
 
-    # This line is optional if you do not want to supress app logs in your <environment>.log
-    config.logstasher.supress_app_log = false
+    # This line is optional if you do not want to suppress app logs in your <environment>.log
+    config.logstasher.suppress_app_log = false
 
 ## Adding custom fields to the log
 

--- a/lib/logstasher.rb
+++ b/lib/logstasher.rb
@@ -56,10 +56,15 @@ module LogStasher
   end
 
   def self.suppress_app_logs(app)
-    if app.config.logstasher.supress_app_log.nil? || app.config.logstasher.supress_app_log
+    if configured_to_suppress_app_logs?(app)
       require 'logstasher/rails_ext/rack/logger'
       LogStasher.remove_existing_log_subscriptions
     end
+  end
+
+  def self.configured_to_suppress_app_logs?(app)
+    # This supports both spellings: "suppress_app_log" and "supress_app_log"
+    !!(app.config.logstasher.suppress_app_log.nil? ? app.config.logstasher.supress_app_log : app.config.logstasher.suppress_app_log)
   end
 
   def self.custom_fields

--- a/spec/logstasher_spec.rb
+++ b/spec/logstasher_spec.rb
@@ -77,13 +77,31 @@ describe LogStasher do
     end
   end
 
-  describe '.supress_app_logs' do
-    let(:logstasher_config){ mock(:logstasher => mock(:supress_app_log => true))}
+  describe '.suppress_app_logs' do
+    let(:logstasher_config){ mock(:logstasher => mock(:suppress_app_log => true))}
     let(:app){ mock(:config => logstasher_config)}
     it 'removes existing subscription if enabled' do
       LogStasher.should_receive(:require).with('logstasher/rails_ext/rack/logger')
       LogStasher.should_receive(:remove_existing_log_subscriptions)
       LogStasher.suppress_app_logs(app)
+    end
+
+    context 'when disabled' do
+      let(:logstasher_config){ mock(:logstasher => mock(:suppress_app_log => false)) }
+      it 'does not remove existing subscription' do
+        LogStasher.should_not_receive(:remove_existing_log_subscriptions)
+        LogStasher.suppress_app_logs(app)
+      end
+
+      describe "backward compatibility" do
+        context 'with spelling "supress_app_log"' do
+          let(:logstasher_config){ mock(:logstasher => mock(:suppress_app_log => nil, :supress_app_log => false)) }
+          it 'does not remove existing subscription' do
+            LogStasher.should_not_receive(:remove_existing_log_subscriptions)
+            LogStasher.suppress_app_logs(app)
+          end
+        end
+      end
     end
   end
 


### PR DESCRIPTION
The spelling of "supress" in the `supress_app_log` configuration option was [not correct](https://www.google.co.uk/search?q=how+to+spell+suppress). As a result, one of our projects ended up suppressing logs when it shouldn't have.

It's our fault for not copy/pasting from the documentation, but it's looks like it may be a very common mistake.

To avoid similar issues in the future, I've fixed the typo, so the supported configuration option is now `suppress_app_log`.

For backward compatibility, `supress_app_log` is still accepted.
