### PR TITLE
removed deprecation warning for mock vs double

### DIFF
--- a/spec/logstasher_logsubscriber_spec.rb
+++ b/spec/logstasher_logsubscriber_spec.rb
@@ -37,8 +37,8 @@ describe LogStasher::RequestLogSubscriber do
   describe '.process_action' do
     let!(:request_subscriber) { @request_subscriber ||= LogStasher::RequestLogSubscriber.new() }
     let(:payload) { {} }
-    let(:event)   { mock(:payload => payload) }
-    let(:logger)  { mock }
+    let(:event)   { double(:payload => payload) }
+    let(:logger)  { double }
     let(:json)    { "{\"@source\":\"unknown\",\"@tags\":[\"request\"],\"@fields\":{\"request\":true,\"status\":true,\"runtimes\":true,\"location\":true,\"exception\":true,\"custom\":true},\"@timestamp\":\"timestamp\"}\n" }
     before do
       LogStasher.stub(:logger => logger)
@@ -148,7 +148,7 @@ describe LogStasher::RequestLogSubscriber do
   end
 
   describe "with append_custom_params block specified" do
-    let(:request) { mock(:remote_ip => '10.0.0.1')}
+    let(:request) { double(:remote_ip => '10.0.0.1')}
     it "should add default custom data to the output" do
       request.stub(:params => event.payload[:params])
       LogStasher.add_default_fields_to_payload(event.payload, request)

--- a/spec/logstasher_spec.rb
+++ b/spec/logstasher_spec.rb
@@ -35,7 +35,7 @@ describe LogStasher do
   describe '.appened_default_info_to_payload' do
     let(:params)  { {'a' => '1', 'b' => 2, 'action' => 'action', 'controller' => 'test'}.with_indifferent_access }
     let(:payload) { {:params => params} }
-    let(:request) { mock(:params => params, :remote_ip => '10.0.0.1')}
+    let(:request) { double(:params => params, :remote_ip => '10.0.0.1')}
     after do
       LogStasher.custom_fields = []
     end
@@ -58,12 +58,12 @@ describe LogStasher do
   end
 
   describe '.setup' do
-    let(:logger) { mock }
-    let(:logstasher_config) { mock(:logger => logger,:log_level => 'warn') }
-    let(:config) { mock(:logstasher => logstasher_config) }
-    let(:app) { mock(:config => config) }
+    let(:logger) { double }
+    let(:logstasher_config) { double(:logger => logger,:log_level => 'warn') }
+    let(:config) { double(:logstasher => logstasher_config) }
+    let(:app) { double(:config => config) }
     before do
-      config.stub(:action_dispatch => mock(:rack_cache => false))
+      config.stub(:action_dispatch => double(:rack_cache => false))
     end
     it 'defines a method in ActionController::Base' do
       LogStasher.should_receive(:require).with('logstasher/rails_ext/action_controller/metal/instrumentation')
@@ -78,8 +78,8 @@ describe LogStasher do
   end
 
   describe '.suppress_app_logs' do
-    let(:logstasher_config){ mock(:logstasher => mock(:suppress_app_log => true))}
-    let(:app){ mock(:config => logstasher_config)}
+    let(:logstasher_config){ double(:logstasher => double(:suppress_app_log => true))}
+    let(:app){ double(:config => logstasher_config)}
     it 'removes existing subscription if enabled' do
       LogStasher.should_receive(:require).with('logstasher/rails_ext/rack/logger')
       LogStasher.should_receive(:remove_existing_log_subscriptions)
@@ -87,7 +87,7 @@ describe LogStasher do
     end
 
     context 'when disabled' do
-      let(:logstasher_config){ mock(:logstasher => mock(:suppress_app_log => false)) }
+      let(:logstasher_config){ double(:logstasher => double(:suppress_app_log => false)) }
       it 'does not remove existing subscription' do
         LogStasher.should_not_receive(:remove_existing_log_subscriptions)
         LogStasher.suppress_app_logs(app)
@@ -95,7 +95,7 @@ describe LogStasher do
 
       describe "backward compatibility" do
         context 'with spelling "supress_app_log"' do
-          let(:logstasher_config){ mock(:logstasher => mock(:suppress_app_log => nil, :supress_app_log => false)) }
+          let(:logstasher_config){ double(:logstasher => double(:suppress_app_log => nil, :supress_app_log => false)) }
           it 'does not remove existing subscription' do
             LogStasher.should_not_receive(:remove_existing_log_subscriptions)
             LogStasher.suppress_app_logs(app)
@@ -120,7 +120,7 @@ describe LogStasher do
   end
 
   describe '.log' do
-    let(:logger) { mock() }
+    let(:logger) { double() }
     before do
       LogStasher.logger = logger
       LogStash::Time.stub(:now => 'timestamp')


### PR DESCRIPTION
Fixed: DEPRECATION: mock is deprecated. Use double instead. 
