### PR TITLE
Prevent error when seeing an exception thrown by Rails.

### DIFF
--- a/lib/logstasher/log_subscriber.rb
+++ b/lib/logstasher/log_subscriber.rb
@@ -14,7 +14,7 @@ module LogStasher
       data.merge! extract_custom_fields(payload)
 
       tags = ['request']
-      tags.push(payload[:exception] ? 'exception' : {})
+      tags.push('exception') if payload[:exception]
       event = LogStash::Event.new('@fields' => data, '@tags' => tags)
       LogStasher.logger << event.to_json + "\n"
     end


### PR DESCRIPTION
Hi,

I tried to use Logstasher 0.2.8 with Rails4 (served by Puma & Ruby 2.0.0-p247 ).
When rails throws an exception, Logstasher doesn't catch and log it, instead the following error is raised:

```
E, [2013-10-14T04:14:43.672210 #8396] ERROR -- : Could not log "process_action.action_controller" event. NoMethodError: undefined method `<<' for nil:NilClass ["/var/www/app/capistrano/current/vendor/bundle/ruby/2.0.0/gems/logstasher-0.2.8/lib/logstasher/log_subscriber.rb:17:in `process_action'", 
```

The change I made fixes the issue and allows the Rails exception to be rendered in Logstasher Json output file.
