### PR TITLE
NoMethodError: undefined method `first' for nil:NilClass

### DIFF
--- a/lib/logstasher/log_subscriber.rb
+++ b/lib/logstasher/log_subscriber.rb
@@ -40,11 +40,7 @@ module LogStasher
     end
 
     def extract_format(payload)
-      if ::ActionPack::VERSION::MAJOR == 3 && ::ActionPack::VERSION::MINOR == 0
-        payload[:formats].first
-      else
-        payload[:format]
-      end
+      payload[:format]
     end
 
     def extract_status(payload)


### PR DESCRIPTION
If action_pack version is 3.0.x, then raise NoMethodError: undefined method `first' for nil:NilClass.

Rails version is 3.0.9.

You can see [here](https://github.com/shadabahmed/logstasher/blob/master/lib/logstasher/rails_ext/action_controller/metal/instrumentation.rb#L8).
