### PR TITLE
Ensure railtie initializer runs before app initializers

### DIFF
--- a/lib/logstasher/railtie.rb
+++ b/lib/logstasher/railtie.rb
@@ -7,7 +7,7 @@ module LogStasher
     config.logstasher = ActiveSupport::OrderedOptions.new
     config.logstasher.enabled = false
 
-    initializer :logstasher do |app|
+    initializer :logstasher, :before => :load_config_initializers do |app|
       LogStasher.setup(app) if app.config.logstasher.enabled
     end
   end


### PR DESCRIPTION
In some situations, this was running after the application initializers, which meant that config for custom fields was not taking effect.

This load-order behaviour seems to depend on what other Engines are installed, and the order they appear in the Gemfile.  In my case, it was the less-rails gem that triggered this behaviour.  If logstasher was declared before it in the Gemfile, everything worked as expected, but if logstasher came after less-rails in the Gemfile, the initializers order was changed, and the custom fields config did not run (because `LogStasher.enabled` was returning nil).
