### PR TITLE
Only log controller parameters when configured to.

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,18 @@ In your Gemfile:
     # This line is optional if you do not want to suppress app logs in your <environment>.log
     config.logstasher.suppress_app_log = false
 
+## Logging params hash
+
+Logstasher can be configured to log the contents of the params hash.  When enabled, the contents of the params hash (minus the ActionController internal params)
+will be added to the log as a deep hash.  This can cause conflicts within the Elasticsearch mappings though, so should be enabled with care.  Conflicts will occur
+if different actions (or even different applications logging to the same Elasticsearch cluster) use the same params key, but with a different data type (e.g. a
+string vs. a hash).  This can lead to lost log entries.  Enabling this can also significantly increase the size of the Elasticsearch indexes.
+
+To enable this, add the following to your `<environment>.rb`
+
+    # Enable logging of controller params
+    config.logstasher.log_controller_parameters = true
+
 ## Adding custom fields to the log
 
 Since some fields are very specific to your application for e.g. *user_name*, so it is left upto you, to add them. Here's how to add those fields to the logs:

--- a/spec/lib/logstasher/log_subscriber_spec.rb
+++ b/spec/lib/logstasher/log_subscriber_spec.rb
@@ -14,7 +14,11 @@ describe LogStasher::RequestLogSubscriber do
   }
   before do
     LogStasher.logger = logger
+    LogStasher.log_controller_parameters = true
     LogStasher.custom_fields = []
+  end
+  after do
+    LogStasher.log_controller_parameters = false
   end
 
   let(:subscriber) {LogStasher::RequestLogSubscriber.new}

--- a/spec/lib/logstasher_spec.rb
+++ b/spec/lib/logstasher_spec.rb
@@ -38,14 +38,23 @@ describe LogStasher do
     let(:request) { double(:params => params, :remote_ip => '10.0.0.1')}
     after do
       LogStasher.custom_fields = []
+      LogStasher.log_controller_parameters = false
     end
     it 'appends default parameters to payload' do
+      LogStasher.log_controller_parameters = true
       LogStasher.custom_fields = []
       LogStasher.add_default_fields_to_payload(payload, request)
       payload[:ip].should == '10.0.0.1'
       payload[:route].should == 'test#action'
       payload[:parameters].should == {'a' => '1', 'b' => 2}
       LogStasher.custom_fields.should == [:ip, :route, :parameters]
+    end
+
+    it 'does not include parameters when not configured to' do
+      LogStasher.custom_fields = []
+      LogStasher.add_default_fields_to_payload(payload, request)
+      payload.should_not have_key(:parameters)
+      LogStasher.custom_fields.should == [:ip, :route]
     end
   end
 
@@ -59,7 +68,7 @@ describe LogStasher do
 
   describe '.setup' do
     let(:logger) { double }
-    let(:logstasher_config) { double(:logger => logger,:log_level => 'warn') }
+    let(:logstasher_config) { double(:logger => logger,:log_level => 'warn',:log_controller_parameters => nil) }
     let(:config) { double(:logstasher => logstasher_config) }
     let(:app) { double(:config => config) }
     before do
@@ -74,6 +83,7 @@ describe LogStasher do
       LogStasher.setup(app)
       LogStasher.enabled.should be_true
       LogStasher.custom_fields.should == []
+      LogStasher.log_controller_parameters.should == false
     end
   end
 


### PR DESCRIPTION
This adds a new config option `log_controller_parameters`, that defaults to false.  This needs to be set to true to enable logging of the params hash, otherwise this is omitted.

Rationale:

The change in shadabahmed/logstasher#14 has implications that are not immediately obvious.  It will cause the elasticsearch mapping for the parameters field to become a new dynamic mapping that gets indexed. This can lead to collisions if different apps (or even different controllers within the same app) use the same params key with different types, which results in log messages being lost.  It also causes the indexes to become significantly larger (in our case, this change tripled the size).

In light of this, I think the not logging these fields by default is the correct choice.
