### PR TITLE
Add custom fields to payload AFTER action is called

### DIFF
--- a/lib/logstasher/rails_ext/action_controller/metal/instrumentation.rb
+++ b/lib/logstasher/rails_ext/action_controller/metal/instrumentation.rb
@@ -11,18 +11,20 @@ module ActionController
       }
 
       LogStasher.add_default_fields_to_payload(raw_payload, request)
-      if self.respond_to?(:logtasher_add_custom_fields_to_payload)
-        before_keys = raw_payload.keys.clone
-        logtasher_add_custom_fields_to_payload(raw_payload)
-        after_keys = raw_payload.keys
-        # Store all extra keys added to payload hash in payload itself. This is a thread safe way
-        LogStasher.custom_fields += after_keys - before_keys
-      end
 
       ActiveSupport::Notifications.instrument("start_processing.action_controller", raw_payload.dup)
 
       ActiveSupport::Notifications.instrument("process_action.action_controller", raw_payload) do |payload|
         result = super
+        
+        if self.respond_to?(:logtasher_add_custom_fields_to_payload)
+          before_keys = raw_payload.keys.clone
+          logtasher_add_custom_fields_to_payload(raw_payload)
+          after_keys = raw_payload.keys
+          # Store all extra keys added to payload hash in payload itself. This is a thread safe way
+          LogStasher.custom_fields += after_keys - before_keys
+        end
+        
         payload[:status] = response.status
         append_info_to_payload(payload)
         result


### PR DESCRIPTION
Imagine we want to log the user id or some session variables, this will be called before any before_filter, including the rails before filter that handles csrf.

This can be bad, for example, [devise memoizes the current resource](https://github.com/plataformatec/devise/blob/master/lib/devise/controllers/helpers.rb#L58), this means that if we want to add `current_user.id` to the custom fields, it will be computed before rails can nullify the session (default behaviour), meaning that CSRF protection will be completely bypassed.
