### PR TITLE
feature: allow listening for arbitrary activesupport instrumentation.

### DIFF
--- a/lib/logstasher/rails_ext/action_controller/metal/instrumentation.rb
+++ b/lib/logstasher/rails_ext/action_controller/metal/instrumentation.rb
@@ -16,7 +16,7 @@ module ActionController
 
       ActiveSupport::Notifications.instrument("process_action.action_controller", raw_payload) do |payload|
         result = super
-        
+
         if self.respond_to?(:logtasher_add_custom_fields_to_payload)
           before_keys = raw_payload.keys.clone
           logtasher_add_custom_fields_to_payload(raw_payload)
@@ -24,9 +24,12 @@ module ActionController
           # Store all extra keys added to payload hash in payload itself. This is a thread safe way
           LogStasher.custom_fields += after_keys - before_keys
         end
-        
+
         payload[:status] = response.status
         append_info_to_payload(payload)
+        LogStasher.store.each do |key, value|
+          payload[key] = value
+        end
         result
       end
     end

--- a/logstasher.gemspec
+++ b/logstasher.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
   s.add_runtime_dependency "logstash-event", ["~> 1.1.0"]
+  s.add_runtime_dependency "request_store"
 
   # specify any dependencies here; for example:
   s.add_development_dependency "rspec"


### PR DESCRIPTION
This pull-requests adds the ability to listen to any ActiveSupport::Notificatios (standard or custom), and store data to be added to the end JSON log.
To track data across events, a store is provided. The store is reset before each request, and automatically namespaced for each kind of notification.

For example, this can be used to compute the average time spent in the db per request, the number of sql queries executed during a request, the cache hit/miss ratio, etc...
