### PR TITLE
fix: execute the block passed to add_custom_field in the proper context

### DIFF
--- a/lib/logstasher.rb
+++ b/lib/logstasher.rb
@@ -46,9 +46,9 @@ module LogStasher
   end
 
   def add_custom_fields(&block)
-    wrapped_block = lambda do |fields|
+    wrapped_block = Proc.new do |fields|
       LogStasher.custom_fields.concat(LogStasher.store.keys)
-      block.call(fields)
+      instance_exec(fields, &block)
     end
     ActionController::Metal.send(:define_method, :logtasher_add_custom_fields_to_payload, &wrapped_block)
     ActionController::Base.send(:define_method, :logtasher_add_custom_fields_to_payload, &wrapped_block)


### PR DESCRIPTION
This fixes a regression introduced in #30 that caused the block passed to `add_custom_fields` to be executed in the wrong context, denying it access to controller methods.

Kudos to @ffmike for finding it, and shame on me for pushing something after an aggressive refactoring without taking enough time to make sure everything worked.
