### PR TITLE
LogStasher now allows you to specify your own path.

### DIFF
--- a/lib/logstasher.rb
+++ b/lib/logstasher.rb
@@ -9,7 +9,7 @@ module LogStasher
   extend self
   STORE_KEY = :logstasher_data
 
-  attr_accessor :logger, :enabled, :log_controller_parameters, :source
+  attr_accessor :logger, :logger_path, :enabled, :log_controller_parameters, :source
   # Setting the default to 'unknown' to define the default behaviour
   @source = 'unknown'
 
@@ -61,7 +61,8 @@ module LogStasher
     require 'logstash-event'
     self.suppress_app_logs(app)
     LogStasher::RequestLogSubscriber.attach_to :action_controller
-    self.logger = app.config.logstasher.logger || new_logger("#{Rails.root}/log/logstash_#{Rails.env}.log")
+    self.logger_path = app.config.logstasher.logger_path || "#{Rails.root}/log/logstash_#{Rails.env}.log"
+    self.logger = app.config.logstasher.logger || new_logger(self.logger_path)
     self.logger.level = app.config.logstasher.log_level || Logger::WARN
     self.source = app.config.logstasher.source unless app.config.logstasher.source.nil?
     self.enabled = true

--- a/spec/lib/logstasher_spec.rb
+++ b/spec/lib/logstasher_spec.rb
@@ -68,7 +68,7 @@ describe LogStasher do
 
   shared_examples 'setup' do
     let(:logstasher_source) { nil }
-    let(:logstasher_config) { double(:logger => logger, :log_level => 'warn', :log_controller_parameters => nil, :source => logstasher_source) }
+    let(:logstasher_config) { double(:logger => logger, :log_level => 'warn', :log_controller_parameters => nil, :source => logstasher_source, :logger_path => logger_path) }
     let(:config) { double(:logstasher => logstasher_config) }
     let(:app) { double(:config => config) }
     before do
@@ -91,14 +91,15 @@ describe LogStasher do
   end
 
   describe '.setup' do
+    let(:logger) { double }
+    let(:logger_path) { nil }
+
     describe 'with source set' do
-      let(:logger) { double }
       let(:logstasher_source) { 'foo' }
       it_behaves_like 'setup'
     end
 
     describe 'without source set (default behaviour)' do
-      let(:logger) { double }
       let(:logstasher_source) { nil }
       it_behaves_like 'setup'
     end
@@ -108,6 +109,13 @@ describe LogStasher do
 
       context 'with no logger passed in' do
         before { LogStasher.should_receive(:new_logger).with('/log/logstash_test.log') }
+        it_behaves_like 'setup'
+      end
+
+      context 'with custom logger path passed in' do
+        let(:logger_path) { double }
+
+        before { LogStasher.should_receive(:new_logger).with(logger_path) }
         it_behaves_like 'setup'
       end
     end


### PR DESCRIPTION
When creating a new logger, you'd need to touch the logfile in order to avoid the comment in line 1. Since this logic already lives within this package, we might as well use it.
