### PR TITLE
Fix "logstasher output with exception" test on Fedora

### DIFF
--- a/spec/lib/logstasher/log_subscriber_spec.rb
+++ b/spec/lib/logstasher/log_subscriber_spec.rb
@@ -116,7 +116,7 @@ describe LogStasher::RequestLogSubscriber do
         event.payload[:exception] = ['AbstractController::ActionNotFound', 'Route not found']
         subscriber.process_action(event)
         log_output.json['@fields']['status'].should >= 400
-        log_output.json['@fields']['error'].should =~ /AbstractController::ActionNotFound.*Route not found.*logstasher\/spec\/lib\/logstasher\/log_subscriber_spec\.rb/m
+        log_output.json['@fields']['error'].should =~ /AbstractController::ActionNotFound.*Route not found.*logstasher.*\/spec\/lib\/logstasher\/log_subscriber_spec\.rb/m
         log_output.json['@tags'].should include 'request'
         log_output.json['@tags'].should include 'exception'
       end


### PR DESCRIPTION
In Fedora the directories with gems are named as GEMNAME-VERSION, but output in this tests is expecting directory "logstasher".

The whole error output was:

```
Failures:

  1) LogStasher::RequestLogSubscriber logstasher output should add a valid status when an exception occurred
     Failure/Error: log_output.json['@fields']['error'].should =~ /AbstractController::ActionNotFound.*Route not found.*logstasher\/spec\/lib\/logstasher\/log_subscriber_spec\.rb/m
       expected: /AbstractController::ActionNotFound.*Route not found.*logstasher\/spec\/lib\/logstasher\/log_subscriber_spec\.rb/m
            got: "AbstractController::ActionNotFound\nRoute not found\n/home/valtri/.gem/ruby/gems/logstasher-0.5.3/spec/lib/logstasher/log_subscriber_spec.rb:112:in `block (3 levels) in <top (required)>'\n/usr/share/gems/gems/rspec-core-2.14.7/lib/rspec/core/example.rb:114:in `instance_eval'\n/usr/share/gems/gems/rspec-core-2.14.7/lib/rspec/core/example.rb:114:in `block in run'\n/usr/share/gems/gems/rspec-core-2.14.7/lib/rspec/core/example.rb:254:in `with_around_each_hooks'\n/usr/share/gems/gems/rspec-core-2.14.7/lib/rspec/core/example.rb:111:in `run'\n/usr/share/gems/gems/rspec-core-2.14.7/lib/rspec/core/example_group.rb:390:in `block in run_examples'\n/usr/share/gems/gems/rspec-core-2.14.7/lib/rspec/core/example_group.rb:386:in `map'\n/usr/share/gems/gems/rspec-core-2.14.7/lib/rspec/core/example_group.rb:386:in `run_examples'\n/usr/share/gems/gems/rspec-core-2.14.7/lib/rspec/core/example_group.rb:371:in `run'\n/usr/share/gems/gems/rspec-core-2.14.7/lib/rspec/core/example_group.rb:372:in `block in run'\n/usr/share/gems/gems/rspec-core-2.14.7/lib/rspec/core/example_group.rb:372:in `map'\n/usr/share/gems/gems/rspec-core-2.14.7/lib/rspec/core/example_group.rb:372:in `run'\n/usr/share/gems/gems/rspec-core-2.14.7/lib/rspec/core/command_line.rb:28:in `block (2 levels) in run'\n/usr/share/gems/gems/rspec-core-2.14.7/lib/rspec/core/command_line.rb:28:in `map'\n/usr/share/gems/gems/rspec-core-2.14.7/lib/rspec/core/command_line.rb:28:in `block in run'\n/usr/share/gems/gems/rspec-core-2.14.7/lib/rspec/core/reporter.rb:58:in `report'\n/usr/share/gems/gems/rspec-core-2.14.7/lib/rspec/core/command_line.rb:25:in `run'\n/usr/share/gems/gems/rspec-core-2.14.7/lib/rspec/core/runner.rb:80:in `run'\n/usr/share/gems/gems/rspec-core-2.14.7/lib/rspec/core/runner.rb:17:in `block in autorun'" (using =~)
       Diff:
       @@ -1,2 +1,22 @@
       -/AbstractController::ActionNotFound.*Route not found.*logstasher\/spec\/lib\/logstasher\/log_subscriber_spec\.rb/m
       +AbstractController::ActionNotFound
       +Route not found
       +/home/valtri/.gem/ruby/gems/logstasher-0.5.3/spec/lib/logstasher/log_subscriber_spec.rb:112:in `block (3 levels) in <top (required)>'
       +/usr/share/gems/gems/rspec-core-2.14.7/lib/rspec/core/example.rb:114:in `instance_eval'
       +/usr/share/gems/gems/rspec-core-2.14.7/lib/rspec/core/example.rb:114:in `block in run'
       +/usr/share/gems/gems/rspec-core-2.14.7/lib/rspec/core/example.rb:254:in `with_around_each_hooks'
       +/usr/share/gems/gems/rspec-core-2.14.7/lib/rspec/core/example.rb:111:in `run'
       +/usr/share/gems/gems/rspec-core-2.14.7/lib/rspec/core/example_group.rb:390:in `block in run_examples'
       +/usr/share/gems/gems/rspec-core-2.14.7/lib/rspec/core/example_group.rb:386:in `map'
       +/usr/share/gems/gems/rspec-core-2.14.7/lib/rspec/core/example_group.rb:386:in `run_examples'
       +/usr/share/gems/gems/rspec-core-2.14.7/lib/rspec/core/example_group.rb:371:in `run'
       +/usr/share/gems/gems/rspec-core-2.14.7/lib/rspec/core/example_group.rb:372:in `block in run'
       +/usr/share/gems/gems/rspec-core-2.14.7/lib/rspec/core/example_group.rb:372:in `map'
       +/usr/share/gems/gems/rspec-core-2.14.7/lib/rspec/core/example_group.rb:372:in `run'
       +/usr/share/gems/gems/rspec-core-2.14.7/lib/rspec/core/command_line.rb:28:in `block (2 levels) in run'
       +/usr/share/gems/gems/rspec-core-2.14.7/lib/rspec/core/command_line.rb:28:in `map'
       +/usr/share/gems/gems/rspec-core-2.14.7/lib/rspec/core/command_line.rb:28:in `block in run'
       +/usr/share/gems/gems/rspec-core-2.14.7/lib/rspec/core/reporter.rb:58:in `report'
       +/usr/share/gems/gems/rspec-core-2.14.7/lib/rspec/core/command_line.rb:25:in `run'
       +/usr/share/gems/gems/rspec-core-2.14.7/lib/rspec/core/runner.rb:80:in `run'
       +/usr/share/gems/gems/rspec-core-2.14.7/lib/rspec/core/runner.rb:17:in `block in autorun'

     # ./spec/lib/logstasher/log_subscriber_spec.rb:119:in `rescue in block (3 levels) in <top (required)>'
     # ./spec/lib/logstasher/log_subscriber_spec.rb:111:in `block (3 levels) in <top (required)>'

Finished in 0.72154 seconds
55 examples, 1 failure

Failed examples:

rspec ./spec/lib/logstasher/log_subscriber_spec.rb:110 # LogStasher::RequestLogSubscriber logstasher output should add a valid status when an exception occurred
```
