### PR TITLE
Prove that timestamps are not working properly in test suite

### DIFF
--- a/spec/lib/logstasher/log_subscriber_spec.rb
+++ b/spec/lib/logstasher/log_subscriber_spec.rb
@@ -43,10 +43,10 @@ describe LogStasher::RequestLogSubscriber do
     let(:payload) { {} }
     let(:event)   { double(:payload => payload) }
     let(:logger)  { double }
-    let(:json)    { "{\"@source\":\"unknown\",\"@tags\":[\"request\"],\"@fields\":{\"request\":true,\"status\":true,\"runtimes\":true,\"location\":true,\"exception\":true,\"custom\":true},\"@timestamp\":\"timestamp\"}\n" }
+    let(:json)    { "{\"@source\":\"unknown\",\"@tags\":[\"request\"],\"@fields\":{\"request\":true,\"status\":true,\"runtimes\":true,\"location\":true,\"exception\":true,\"custom\":true},\"@timestamp\":\"1970-01-01T00:00:00Z\"}\n" }
     before do
       allow(LogStasher).to receive(:logger).and_return(logger)
-      allow(LogStash::Time).to receive(:now).and_return('timestamp')
+      allow(LogStash::Time).to receive(:now).and_return(Time.at(0).gmtime)
     end
     it 'calls all extractors and outputs the json' do
       expect(request_subscriber).to receive(:extract_request).with(payload).and_return({:request => true})

--- a/spec/lib/logstasher_spec.rb
+++ b/spec/lib/logstasher_spec.rb
@@ -195,12 +195,12 @@ describe LogStasher do
     let(:logger) { double() }
     before do
       LogStasher.logger = logger
-      allow(LogStash::Time).to receive_messages(:now => 'timestamp')
+      allow(LogStash::Time).to receive_messages(:now => Time.at(0).gmtime)
       allow_message_expectations_on_nil
     end
     it 'adds to log with specified level' do
       expect(logger).to receive(:send).with('warn?').and_return(true)
-      expect(logger).to receive(:send).with('warn',"{\"@source\":\"unknown\",\"@tags\":[\"log\"],\"@fields\":{\"message\":\"WARNING\",\"level\":\"warn\"},\"@timestamp\":\"timestamp\"}")
+      expect(logger).to receive(:send).with('warn',"{\"@source\":\"unknown\",\"@tags\":[\"log\"],\"@fields\":{\"message\":\"WARNING\",\"level\":\"warn\"},\"@timestamp\":\"1970-01-01T00:00:00Z\"}")
       LogStasher.log('warn', 'WARNING')
     end
     context 'with a source specified' do
@@ -209,7 +209,7 @@ describe LogStasher do
       end
       it 'sets the correct source' do
         expect(logger).to receive(:send).with('warn?').and_return(true)
-        expect(logger).to receive(:send).with('warn',"{\"@source\":\"foo\",\"@tags\":[\"log\"],\"@fields\":{\"message\":\"WARNING\",\"level\":\"warn\"},\"@timestamp\":\"timestamp\"}")
+        expect(logger).to receive(:send).with('warn',"{\"@source\":\"foo\",\"@tags\":[\"log\"],\"@fields\":{\"message\":\"WARNING\",\"level\":\"warn\"},\"@timestamp\":\"1970-01-01T00:00:00Z\"}")
         LogStasher.log('warn', 'WARNING')
       end
     end


### PR DESCRIPTION
This commit uncovers the same test failure that's present in #54, only without the features of that PR. Effectively, it proves that the string that was mocking timestamp was covering up strange behavior. To make matters even stranger, this behavior does not seem to follow through to actual Rails applications in either, Rails 3 or 4 - timestamps have a subsecond precision in both. This is looking an awful lot like some type of test pollution or other form of environment-based cause.

There is no need to merge this PR, but I feel it should be brought to the attention of the developers, given that it was cited as a blocking factor for merging #54. In the mean time, I will provide a new commit for #54, that expects one timestamp in Rails 3, and another in Rails 4 - I think the proper solution is to remove this strange behavior (possibly an errant monkey patch somewhere in the Rails dependency trees?), but I have not been successful in that approach.