### PR TITLE
Call logtasher_add_custom_fields_to_payload in

### DIFF
--- a/lib/logstasher/rails_ext/action_controller/metal/instrumentation.rb
+++ b/lib/logstasher/rails_ext/action_controller/metal/instrumentation.rb
@@ -22,8 +22,6 @@ module ActionController
           logstasher_add_custom_fields_to_request_context(LogStasher.request_context)
         end
 
-        result = super
-
         if self.respond_to?(:logtasher_add_custom_fields_to_payload)
           before_keys = raw_payload.keys.clone
           logtasher_add_custom_fields_to_payload(raw_payload)
@@ -31,6 +29,8 @@ module ActionController
           # Store all extra keys added to payload hash in payload itself. This is a thread safe way
           LogStasher.custom_fields += after_keys - before_keys
         end
+
+        result = super
 
         payload[:status] = response.status
         append_info_to_payload(payload)


### PR DESCRIPTION
advance, otherwise custom fields will not be appended when exceptions
are raised in Rails.