### PR TITLE
Fixing the log method to send only JSON content

### DIFF
--- a/lib/logstasher.rb
+++ b/lib/logstasher.rb
@@ -117,7 +117,7 @@ module LogStasher
   def log(severity, msg)
     if self.logger && self.logger.send("#{severity}?")
       event = LogStash::Event.new('@source' => self.source, '@fields' => {:message => msg, :level => severity}, '@tags' => ['log'])
-      self.logger.send severity, event.to_json
+      self.logger << event.to_json + "\n"
     end
   end
 

--- a/spec/lib/logstasher_spec.rb
+++ b/spec/lib/logstasher_spec.rb
@@ -200,7 +200,7 @@ describe LogStasher do
     end
     it 'adds to log with specified level' do
       expect(logger).to receive(:send).with('warn?').and_return(true)
-      expect(logger).to receive(:send).with('warn',"{\"@source\":\"unknown\",\"@tags\":[\"log\"],\"@fields\":{\"message\":\"WARNING\",\"level\":\"warn\"},\"@timestamp\":\"timestamp\"}")
+      expect(logger).to receive(:<<).with("{\"@source\":\"unknown\",\"@tags\":[\"log\"],\"@fields\":{\"message\":\"WARNING\",\"level\":\"warn\"},\"@timestamp\":\"timestamp\"}\n")
       LogStasher.log('warn', 'WARNING')
     end
     context 'with a source specified' do
@@ -209,7 +209,7 @@ describe LogStasher do
       end
       it 'sets the correct source' do
         expect(logger).to receive(:send).with('warn?').and_return(true)
-        expect(logger).to receive(:send).with('warn',"{\"@source\":\"foo\",\"@tags\":[\"log\"],\"@fields\":{\"message\":\"WARNING\",\"level\":\"warn\"},\"@timestamp\":\"timestamp\"}")
+        expect(logger).to receive(:<<).with("{\"@source\":\"foo\",\"@tags\":[\"log\"],\"@fields\":{\"message\":\"WARNING\",\"level\":\"warn\"},\"@timestamp\":\"timestamp\"}\n")
         LogStasher.log('warn', 'WARNING')
       end
     end


### PR DESCRIPTION
Following this issue, and the suggestion from this issue: https://github.com/shadabahmed/logstasher/issues/41
Changing the `log` method to write only 100% JSON logs, and changing the corresponding tests.

