### PR TITLE
Remove "@fields" key and move it's contents to root of json object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+## 1.0.0 (unreleased)
+
+Breaking Changes:
+
+  - custom fields are now added to the root of the json object instead of being nested inside of "@fields"

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Completed 200 OK in 532ms (Views: 62.4ms | ActiveRecord: 0.0ms | ND API: 0.0ms)
 After **logstasher**:
 
 ```
-{"@source":"unknown","@tags":["request"],"method":"GET","path":"/","format":"html","controller":"file_servers"
+{"source":"unknown","tags":["request"],"method":"GET","path":"/","format":"html","controller":"file_servers"
 ,"action":"index","status":200,"duration":28.34,"view":25.96,"db":0.88,"ip":"127.0.0.1","route":"file_servers#index",
 "parameters":"","uuid":"e81ecd178ed3b591099f4d489760dfb6","user":"shadab_ahmed@abc.com",
 "site":"internal","@timestamp":"2013-04-30T13:00:46.354500+00:00"}
@@ -61,7 +61,7 @@ In your Gemfile:
     # This line is optional if you do not want to suppress app logs in your <environment>.log
     config.logstasher.suppress_app_log = false
 
-    # This line is optional, it allows you to set a custom value for the @source field of the log event
+    # This line is optional, it allows you to set a custom value for the source field of the log event
     config.logstasher.source = 'your.arbitrary.source'
 
     # This line is optional if you do not want to log the backtrace of exceptions
@@ -121,7 +121,7 @@ It is possible to listen to any `ActiveSupport::Notifications` events and store 
 Would change the log entry to:
 
 ```
-{"@source":"unknown","@tags":["request"],"method":"GET","path":"/","format":"html","controller":"file_servers","action":"index","status":200,"duration":28.34,"view":25.96,"db":0.88,"ip":"127.0.0.1","route":"file_servers#index", "parameters":"","uuid":"e81ecd178ed3b591099f4d489760dfb6","user":"shadab_ahmed@abc.com", "site":"internal","some.activesupport.notification":{"count":42},"@timestamp":"2013-04-30T13:00:46.354500+00:00"}
+{"source":"unknown","tags":["request"],"method":"GET","path":"/","format":"html","controller":"file_servers","action":"index","status":200,"duration":28.34,"view":25.96,"db":0.88,"ip":"127.0.0.1","route":"file_servers#index", "parameters":"","uuid":"e81ecd178ed3b591099f4d489760dfb6","user":"shadab_ahmed@abc.com", "site":"internal","some.activesupport.notification":{"count":42},"@timestamp":"2013-04-30T13:00:46.354500+00:00"}
 ```
 
 The store exposed to the blocked passed to `watch` is thread-safe, and reset after each request.

--- a/README.md
+++ b/README.md
@@ -39,10 +39,10 @@ Completed 200 OK in 532ms (Views: 62.4ms | ActiveRecord: 0.0ms | ND API: 0.0ms)
 After **logstasher**:
 
 ```
-{"@source":"unknown","@tags":["request"],"@fields":{"method":"GET","path":"/","format":"html","controller":"file_servers"
+{"@source":"unknown","@tags":["request"],"method":"GET","path":"/","format":"html","controller":"file_servers"
 ,"action":"index","status":200,"duration":28.34,"view":25.96,"db":0.88,"ip":"127.0.0.1","route":"file_servers#index",
-"parameters":"","ndapi_time":null,"uuid":"e81ecd178ed3b591099f4d489760dfb6","user":"shadab_ahmed@abc.com",
-"site":"internal"},"@timestamp":"2013-04-30T13:00:46.354500+00:00"}
+"parameters":"","uuid":"e81ecd178ed3b591099f4d489760dfb6","user":"shadab_ahmed@abc.com",
+"site":"internal","@timestamp":"2013-04-30T13:00:46.354500+00:00"}
 ```
 
 By default, the older format rails request logs are disabled, though you can enable them.
@@ -121,7 +121,7 @@ It is possible to listen to any `ActiveSupport::Notifications` events and store 
 Would change the log entry to:
 
 ```
-{"@source":"unknown","@tags":["request"],"@fields":{"method":"GET","path":"/","format":"html","controller":"file_servers","action":"index","status":200,"duration":28.34,"view":25.96,"db":0.88,"ip":"127.0.0.1","route":"file_servers#index", "parameters":"","ndapi_time":null,"uuid":"e81ecd178ed3b591099f4d489760dfb6","user":"shadab_ahmed@abc.com", "site":"internal","some.activesupport.notification":{"count":42}},"@timestamp":"2013-04-30T13:00:46.354500+00:00"}
+{"@source":"unknown","@tags":["request"],"method":"GET","path":"/","format":"html","controller":"file_servers","action":"index","status":200,"duration":28.34,"view":25.96,"db":0.88,"ip":"127.0.0.1","route":"file_servers#index", "parameters":"","uuid":"e81ecd178ed3b591099f4d489760dfb6","user":"shadab_ahmed@abc.com", "site":"internal","some.activesupport.notification":{"count":42},"@timestamp":"2013-04-30T13:00:46.354500+00:00"}
 ```
 
 The store exposed to the blocked passed to `watch` is thread-safe, and reset after each request.

--- a/lib/logstasher.rb
+++ b/lib/logstasher.rb
@@ -116,7 +116,14 @@ module LogStasher
 
   def log(severity, msg)
     if self.logger && self.logger.send("#{severity}?")
-      event = LogStash::Event.new('@source' => self.source, '@fields' => {:message => msg, :level => severity}, '@tags' => ['log'])
+
+      event = LogStash::Event.new(
+        :message => msg,
+        :level => severity,
+        '@source' => self.source,
+        '@tags' => ['log']
+      )
+
       self.logger << event.to_json + "\n"
     end
   end

--- a/lib/logstasher.rb
+++ b/lib/logstasher.rb
@@ -119,7 +119,7 @@ module LogStasher
 
       event = LogStash::Event.new(
         :message => msg,
-        :severity => severity,
+        :level => severity,
         :source => self.source,
         :tags => ['log']
       )

--- a/lib/logstasher.rb
+++ b/lib/logstasher.rb
@@ -12,7 +12,7 @@ module LogStasher
 
   attr_accessor :logger, :logger_path, :enabled, :log_controller_parameters, :source, :backtrace
   # Setting the default to 'unknown' to define the default behaviour
-  @source = nil
+  @source = "unknown"
   # By default log the backtrace of exceptions
   @backtrace = true
 

--- a/lib/logstasher.rb
+++ b/lib/logstasher.rb
@@ -12,7 +12,7 @@ module LogStasher
 
   attr_accessor :logger, :logger_path, :enabled, :log_controller_parameters, :source, :backtrace
   # Setting the default to 'unknown' to define the default behaviour
-  @source = 'unknown'
+  @source = nil
   # By default log the backtrace of exceptions
   @backtrace = true
 
@@ -119,9 +119,9 @@ module LogStasher
 
       event = LogStash::Event.new(
         :message => msg,
-        :level => severity,
-        '@source' => self.source,
-        '@tags' => ['log']
+        :severity => severity,
+        :source => self.source,
+        :tags => ['log']
       )
 
       self.logger << event.to_json + "\n"

--- a/lib/logstasher/log_subscriber.rb
+++ b/lib/logstasher/log_subscriber.rb
@@ -17,7 +17,7 @@ module LogStasher
       tags.push('exception') if payload[:exception]
 
       event = LogStash::Event.new(
-        data.reverse_merge! '@source' => LogStasher.source, '@tags' => tags
+        { :source => LogStasher.source, :tags => tags }.merge(data)
       )
 
       LogStasher.logger << event.to_json + "\n"
@@ -128,7 +128,7 @@ module LogStasher
       data = LogStasher.request_context.merge(extract_metadata(event.payload))
 
       event = LogStash::Event.new(
-        data.reverse_merge! '@source' => LogStasher.source, '@tags' => tags
+        { :source => LogStasher.source, :tags => tags }.merge(data)
       )
 
       logger << event.to_json + "\n"

--- a/lib/logstasher/log_subscriber.rb
+++ b/lib/logstasher/log_subscriber.rb
@@ -15,7 +15,11 @@ module LogStasher
 
       tags = ['request']
       tags.push('exception') if payload[:exception]
-      event = LogStash::Event.new('@source' => LogStasher.source, '@fields' => data, '@tags' => tags)
+
+      event = LogStash::Event.new(
+        data.reverse_merge! '@source' => LogStasher.source, '@tags' => tags
+      )
+
       LogStasher.logger << event.to_json + "\n"
     end
 
@@ -122,7 +126,11 @@ module LogStasher
 
     def process_event(event, tags)
       data = LogStasher.request_context.merge(extract_metadata(event.payload))
-      event = LogStash::Event.new('@source' => LogStasher.source, '@fields' => data, '@tags' => tags)
+
+      event = LogStash::Event.new(
+        data.reverse_merge! '@source' => LogStasher.source, '@tags' => tags
+      )
+
       logger << event.to_json + "\n"
     end
 

--- a/lib/logstasher/version.rb
+++ b/lib/logstasher/version.rb
@@ -1,3 +1,3 @@
 module LogStasher
-  VERSION = "0.6.2"
+  VERSION = "1.0.0"
 end

--- a/logstasher.gemspec
+++ b/logstasher.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
 
   s.files         = `git ls-files lib`.split("\n")
 
-  s.add_runtime_dependency 'logstash-event', '~> 1.1.0'
+  s.add_runtime_dependency 'logstash-event', '~> 1.2.0'
   s.add_runtime_dependency 'request_store'
 
   s.add_development_dependency('rspec', '>= 2.14')

--- a/sample_logstash_configurations/quickstart.conf
+++ b/sample_logstash_configurations/quickstart.conf
@@ -1,11 +1,11 @@
 input {
-  file { 
+  file {
     type => "rails logs"
     path => "/Users/shadab/test_project/logstash_development.log"
-    codec =>   json {
+    codec => json {
       charset => "UTF-8"
     }
-  } 
+  }
 }
 
 output {
@@ -13,7 +13,7 @@ output {
   stdout {
     codec => rubydebug
   }
-  
+
   elasticsearch {
     # Setting 'embedded' will run  a real elasticsearch server inside logstash.
     # This option below saves you from having to run a separate process just

--- a/spec/lib/logstasher/log_subscriber_spec.rb
+++ b/spec/lib/logstasher/log_subscriber_spec.rb
@@ -50,8 +50,8 @@ describe LogStasher::RequestLogSubscriber do
         "location" => true,
         "exception" => true,
         "custom" => true,
-        "@source" => "unknown",
-        "@tags" => ["request"],
+        "source" => "unknown",
+        "tags" => ["request"],
         "@timestamp" => "timestamp",
         "@version" => "1"
       }.to_json + "\n"
@@ -76,7 +76,7 @@ describe LogStasher::RequestLogSubscriber do
 
     it "should contain request tag" do
       subscriber.process_action(event)
-      expect(log_output.json['@tags']).to include 'request'
+      expect(log_output.json['tags']).to include 'request'
     end
 
     it "should contain HTTP method" do
@@ -129,8 +129,8 @@ describe LogStasher::RequestLogSubscriber do
         subscriber.process_action(event)
         expect(log_output.json['status']).to be >= 400
         expect(log_output.json['error']).to be =~ /AbstractController::ActionNotFound.*Route not found.*logstasher.*\/spec\/lib\/logstasher\/log_subscriber_spec\.rb/m
-        expect(log_output.json['@tags']).to include 'request'
-        expect(log_output.json['@tags']).to include 'exception'
+        expect(log_output.json['tags']).to include 'request'
+        expect(log_output.json['tags']).to include 'exception'
       end
     end
 
@@ -242,8 +242,8 @@ describe LogStasher::MailerLogSubscriber do
   it 'receive an e-mail' do
     SampleMailer.receive(message.encoded)
     log_output.json.tap do |json|
-      expect(json['@source']).to eq(LogStasher.source)
-      expect(json['@tags']).to eq(['mailer', 'receive'])
+      expect(json['source']).to eq(LogStasher.source)
+      expect(json['tags']).to eq(['mailer', 'receive'])
       expect(json['mailer']).to eq('SampleMailer')
       expect(json['from']).to eq(['some-dude@example.com'])
       expect(json['to']).to eq(['some-other-dude@example.com'])
@@ -256,8 +256,8 @@ describe LogStasher::MailerLogSubscriber do
 
     if version = ENV['RAILS_VERSION'] and version >= '4.1'
       log_output.json.tap do |json|
-        expect(json['@source']).to eq(LogStasher.source)
-        expect(json['@tags']).to eq(['mailer', 'process'])
+        expect(json['source']).to eq(LogStasher.source)
+        expect(json['tags']).to eq(['mailer', 'process'])
         expect(json['mailer']).to eq('SampleMailer')
         expect(json['action']).to eq('welcome')
       end
@@ -265,8 +265,8 @@ describe LogStasher::MailerLogSubscriber do
 
     email.deliver
     log_output.json.tap do |json|
-      expect(json['@source']).to eq(LogStasher.source)
-      expect(json['@tags']).to eq(['mailer', 'deliver'])
+      expect(json['source']).to eq(LogStasher.source)
+      expect(json['tags']).to eq(['mailer', 'deliver'])
       expect(json['mailer']).to eq('SampleMailer')
       expect(json['from']).to eq(['some-dude@example.com'])
       expect(json['to']).to eq(['some-other-dude@example.com'])

--- a/spec/lib/logstasher/log_subscriber_spec.rb
+++ b/spec/lib/logstasher/log_subscriber_spec.rb
@@ -44,14 +44,15 @@ describe LogStasher::RequestLogSubscriber do
     let(:event)   { double(:payload => payload) }
     let(:logger)  { double }
     let(:json)    {
-      { "request" => true,
+      {
+        "source" => "unknown",
+        "tags" => ["request"],
+        "request" => true,
         "status" => true,
         "runtimes" => true,
         "location" => true,
         "exception" => true,
         "custom" => true,
-        "source" => "unknown",
-        "tags" => ["request"],
         "@timestamp" => "timestamp",
         "@version" => "1"
       }.to_json + "\n"

--- a/spec/lib/logstasher/log_subscriber_spec.rb
+++ b/spec/lib/logstasher/log_subscriber_spec.rb
@@ -43,10 +43,22 @@ describe LogStasher::RequestLogSubscriber do
     let(:payload) { {} }
     let(:event)   { double(:payload => payload) }
     let(:logger)  { double }
-    let(:json)    { "{\"@source\":\"unknown\",\"@tags\":[\"request\"],\"@fields\":{\"request\":true,\"status\":true,\"runtimes\":true,\"location\":true,\"exception\":true,\"custom\":true},\"@timestamp\":\"timestamp\"}\n" }
+    let(:json)    {
+      { "request" => true,
+        "status" => true,
+        "runtimes" => true,
+        "location" => true,
+        "exception" => true,
+        "custom" => true,
+        "@source" => "unknown",
+        "@tags" => ["request"],
+        "@timestamp" => "timestamp",
+        "@version" => "1"
+      }.to_json + "\n"
+    }
     before do
       allow(LogStasher).to receive(:logger).and_return(logger)
-      allow(LogStash::Time).to receive(:now).and_return('timestamp')
+      allow(Time).to receive_message_chain(:now, :utc).and_return('timestamp')
     end
     it 'calls all extractors and outputs the json' do
       expect(request_subscriber).to receive(:extract_request).with(payload).and_return({:request => true})
@@ -69,42 +81,42 @@ describe LogStasher::RequestLogSubscriber do
 
     it "should contain HTTP method" do
       subscriber.process_action(event)
-      expect(log_output.json['@fields']['method']).to eq 'GET'
+      expect(log_output.json['method']).to eq 'GET'
     end
 
     it "should include the path in the log output" do
       subscriber.process_action(event)
-      expect(log_output.json['@fields']['path']).to eq '/home'
+      expect(log_output.json['path']).to eq '/home'
     end
 
     it "should include the format in the log output" do
       subscriber.process_action(event)
-      expect(log_output.json['@fields']['format']).to eq 'application/json'
+      expect(log_output.json['format']).to eq 'application/json'
     end
 
     it "should include the status code" do
       subscriber.process_action(event)
-      expect(log_output.json['@fields']['status']).to eq 200
+      expect(log_output.json['status']).to eq 200
     end
 
     it "should include the controller" do
       subscriber.process_action(event)
-      expect(log_output.json['@fields']['controller']).to eq 'home'
+      expect(log_output.json['controller']).to eq 'home'
     end
 
     it "should include the action" do
       subscriber.process_action(event)
-      expect(log_output.json['@fields']['action']).to eq 'index'
+      expect(log_output.json['action']).to eq 'index'
     end
 
     it "should include the view rendering time" do
       subscriber.process_action(event)
-      expect(log_output.json['@fields']['view']).to eq 0.01
+      expect(log_output.json['view']).to eq 0.01
     end
 
     it "should include the database rendering time" do
       subscriber.process_action(event)
-      expect(log_output.json['@fields']['db']).to eq 0.02
+      expect(log_output.json['db']).to eq 0.02
     end
 
     it "should add a valid status when an exception occurred" do
@@ -115,8 +127,8 @@ describe LogStasher::RequestLogSubscriber do
         event.payload[:status] = nil
         event.payload[:exception] = ['AbstractController::ActionNotFound', 'Route not found']
         subscriber.process_action(event)
-        expect(log_output.json['@fields']['status']).to be >= 400
-        expect(log_output.json['@fields']['error']).to be =~ /AbstractController::ActionNotFound.*Route not found.*logstasher.*\/spec\/lib\/logstasher\/log_subscriber_spec\.rb/m
+        expect(log_output.json['status']).to be >= 400
+        expect(log_output.json['error']).to be =~ /AbstractController::ActionNotFound.*Route not found.*logstasher.*\/spec\/lib\/logstasher\/log_subscriber_spec\.rb/m
         expect(log_output.json['@tags']).to include 'request'
         expect(log_output.json['@tags']).to include 'exception'
       end
@@ -126,7 +138,7 @@ describe LogStasher::RequestLogSubscriber do
       event.payload[:status] = nil
       event.payload[:exception] = nil
       subscriber.process_action(event)
-      expect(log_output.json['@fields']['status']).to eq 0
+      expect(log_output.json['status']).to eq 0
     end
 
     describe "with a redirect" do
@@ -136,7 +148,7 @@ describe LogStasher::RequestLogSubscriber do
 
       it "should add the location to the log line" do
         subscriber.process_action(event)
-        expect(log_output.json['@fields']['location']).to eq 'http://www.example.com'
+        expect(log_output.json['location']).to eq 'http://www.example.com'
       end
 
       it "should remove the thread local variable" do
@@ -147,7 +159,7 @@ describe LogStasher::RequestLogSubscriber do
 
     it "should not include a location by default" do
       subscriber.process_action(event)
-      expect(log_output.json['@fields']['location']).to be_nil
+      expect(log_output.json['location']).to be_nil
     end
   end
 
@@ -157,9 +169,9 @@ describe LogStasher::RequestLogSubscriber do
       allow(request).to receive_messages(:params => event.payload[:params])
       LogStasher.add_default_fields_to_payload(event.payload, request)
       subscriber.process_action(event)
-      expect(log_output.json['@fields']['ip']).to eq '10.0.0.1'
-      expect(log_output.json['@fields']['route']).to eq'home#index'
-      expect(log_output.json['@fields']['parameters']).to eq 'foo' => 'bar'
+      expect(log_output.json['ip']).to eq '10.0.0.1'
+      expect(log_output.json['route']).to eq'home#index'
+      expect(log_output.json['parameters']).to eq 'foo' => 'bar'
     end
   end
 
@@ -177,7 +189,7 @@ describe LogStasher::RequestLogSubscriber do
     it "should add the custom data to the output" do
       @block.call(event.payload)
       subscriber.process_action(event)
-      expect(log_output.json['@fields']['user']).to eq 'user'
+      expect(log_output.json['user']).to eq 'user'
     end
   end
 
@@ -223,7 +235,7 @@ describe LogStasher::MailerLogSubscriber do
 
   describe "#logger" do
     it "returns an instance of Logstash::Logger" do
-      LogStasher::MailerLogSubscriber.new.logger.should == logger
+      expect(LogStasher::MailerLogSubscriber.new.logger).to eq(logger)
     end
   end
 
@@ -232,12 +244,10 @@ describe LogStasher::MailerLogSubscriber do
     log_output.json.tap do |json|
       expect(json['@source']).to eq(LogStasher.source)
       expect(json['@tags']).to eq(['mailer', 'receive'])
-      json['@fields'].tap do |fields|
-        expect(fields['mailer']).to eq('SampleMailer')
-        expect(fields['from']).to eq(['some-dude@example.com'])
-        expect(fields['to']).to eq(['some-other-dude@example.com'])
-        expect(fields['message_id']).to eq(message.message_id)
-      end
+      expect(json['mailer']).to eq('SampleMailer')
+      expect(json['from']).to eq(['some-dude@example.com'])
+      expect(json['to']).to eq(['some-other-dude@example.com'])
+      expect(json['message_id']).to eq(message.message_id)
     end
   end
 
@@ -248,10 +258,8 @@ describe LogStasher::MailerLogSubscriber do
       log_output.json.tap do |json|
         expect(json['@source']).to eq(LogStasher.source)
         expect(json['@tags']).to eq(['mailer', 'process'])
-        json['@fields'].tap do |fields|
-          expect(fields['mailer']).to eq('SampleMailer')
-          expect(fields['action']).to eq('welcome')
-        end
+        expect(json['mailer']).to eq('SampleMailer')
+        expect(json['action']).to eq('welcome')
       end
     end
 
@@ -259,13 +267,11 @@ describe LogStasher::MailerLogSubscriber do
     log_output.json.tap do |json|
       expect(json['@source']).to eq(LogStasher.source)
       expect(json['@tags']).to eq(['mailer', 'deliver'])
-      json['@fields'].tap do |fields|
-        expect(fields['mailer']).to eq('SampleMailer')
-        expect(fields['from']).to eq(['some-dude@example.com'])
-        expect(fields['to']).to eq(['some-other-dude@example.com'])
-        # Message-Id appears not to be yet available at this point in time.
-        expect(fields['message_id']).to be_nil
-      end
+      expect(json['mailer']).to eq('SampleMailer')
+      expect(json['from']).to eq(['some-dude@example.com'])
+      expect(json['to']).to eq(['some-other-dude@example.com'])
+      # Message-Id appears not to be yet available at this point in time.
+      expect(json['message_id']).to be_nil
     end
   end
 end

--- a/spec/lib/logstasher_spec.rb
+++ b/spec/lib/logstasher_spec.rb
@@ -202,7 +202,7 @@ describe LogStasher do
       expect(logger).to receive(:send).with('warn?').and_return(true)
       expect(logger).to receive(:<<).with(
         { "message"    => "WARNING",
-          "level"      => "warn",
+          "severity"      => "warn",
           "source"    => "unknown",
           "tags"      => ["log"],
           "@timestamp" => "timestamp",
@@ -219,7 +219,7 @@ describe LogStasher do
         expect(logger).to receive(:send).with('warn?').and_return(true)
         expect(logger).to receive(:<<).with(
           { "message"    => "WARNING",
-            "level"      => "warn",
+            "severity"      => "warn",
             "source"    => "foo",
             "tags"      => ["log"],
             "@timestamp" => "timestamp",

--- a/spec/lib/logstasher_spec.rb
+++ b/spec/lib/logstasher_spec.rb
@@ -202,7 +202,7 @@ describe LogStasher do
       expect(logger).to receive(:send).with('warn?').and_return(true)
       expect(logger).to receive(:<<).with(
         { "message"    => "WARNING",
-          "severity"      => "warn",
+          "level"      => "warn",
           "source"    => "unknown",
           "tags"      => ["log"],
           "@timestamp" => "timestamp",
@@ -219,7 +219,7 @@ describe LogStasher do
         expect(logger).to receive(:send).with('warn?').and_return(true)
         expect(logger).to receive(:<<).with(
           { "message"    => "WARNING",
-            "severity"      => "warn",
+            "level"      => "warn",
             "source"    => "foo",
             "tags"      => ["log"],
             "@timestamp" => "timestamp",

--- a/spec/lib/logstasher_spec.rb
+++ b/spec/lib/logstasher_spec.rb
@@ -203,8 +203,8 @@ describe LogStasher do
       expect(logger).to receive(:<<).with(
         { "message"    => "WARNING",
           "level"      => "warn",
-          "@source"    => "unknown",
-          "@tags"      => ["log"],
+          "source"    => "unknown",
+          "tags"      => ["log"],
           "@timestamp" => "timestamp",
           "@version"   => "1"
         }.to_json + "\n"
@@ -220,8 +220,8 @@ describe LogStasher do
         expect(logger).to receive(:<<).with(
           { "message"    => "WARNING",
             "level"      => "warn",
-            "@source"    => "foo",
-            "@tags"      => ["log"],
+            "source"    => "foo",
+            "tags"      => ["log"],
             "@timestamp" => "timestamp",
             "@version"   => "1"
           }.to_json + "\n"

--- a/spec/lib/logstasher_spec.rb
+++ b/spec/lib/logstasher_spec.rb
@@ -195,12 +195,20 @@ describe LogStasher do
     let(:logger) { double() }
     before do
       LogStasher.logger = logger
-      allow(LogStash::Time).to receive_messages(:now => 'timestamp')
+      allow(Time).to receive_message_chain(:now, :utc).and_return('timestamp')
       allow_message_expectations_on_nil
     end
     it 'adds to log with specified level' do
       expect(logger).to receive(:send).with('warn?').and_return(true)
-      expect(logger).to receive(:<<).with("{\"@source\":\"unknown\",\"@tags\":[\"log\"],\"@fields\":{\"message\":\"WARNING\",\"level\":\"warn\"},\"@timestamp\":\"timestamp\"}\n")
+      expect(logger).to receive(:<<).with(
+        { "message"    => "WARNING",
+          "level"      => "warn",
+          "@source"    => "unknown",
+          "@tags"      => ["log"],
+          "@timestamp" => "timestamp",
+          "@version"   => "1"
+        }.to_json + "\n"
+      )
       LogStasher.log('warn', 'WARNING')
     end
     context 'with a source specified' do
@@ -209,7 +217,15 @@ describe LogStasher do
       end
       it 'sets the correct source' do
         expect(logger).to receive(:send).with('warn?').and_return(true)
-        expect(logger).to receive(:<<).with("{\"@source\":\"foo\",\"@tags\":[\"log\"],\"@fields\":{\"message\":\"WARNING\",\"level\":\"warn\"},\"@timestamp\":\"timestamp\"}\n")
+        expect(logger).to receive(:<<).with(
+          { "message"    => "WARNING",
+            "level"      => "warn",
+            "@source"    => "foo",
+            "@tags"      => ["log"],
+            "@timestamp" => "timestamp",
+            "@version"   => "1"
+          }.to_json + "\n"
+        )
         LogStasher.log('warn', 'WARNING')
       end
     end


### PR DESCRIPTION
References #63

This is a breaking change i.e. backwards incompatible with previous versions of logstasher, hence the major version change.