### PR TITLE
Updated readme with logger path instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,9 @@ In your Gemfile:
 
     # This line is optional if you do not want to log the backtrace of exceptions
     config.logstasher.backtrace = false
+    
+    # This line is optional, defaults to log/logstasher_<environment>.log
+    config.logstasher.logger_path = 'log/logstasher.log'
 
 ## Logging params hash
 


### PR DESCRIPTION
Current readme doesn't include instructions on simple logger_path config setting, almost switched gems before digging through code to realize this was an option.