### PR TITLE
Allow logstasher to log to STDOUT

### DIFF
--- a/lib/logstasher.rb
+++ b/lib/logstasher.rb
@@ -156,7 +156,9 @@ module LogStasher
   private
 
   def new_logger(path)
-    FileUtils.touch path # prevent autocreate messages in log
+    if path.is_a? String
+      FileUtils.touch path # prevent autocreate messages in log
+    end
     Logger.new path
   end
 end


### PR DESCRIPTION
This allows logstasher to log to STDOUT if it is configured as such `config.logstasher.logger_path = STDOUT`