### PR TITLE
LogStasher.log calls conform to logstash schema v1.

### DIFF
--- a/lib/logstasher.rb
+++ b/lib/logstasher.rb
@@ -116,7 +116,7 @@ module LogStasher
 
   def log(severity, msg)
     if self.logger && self.logger.send("#{severity}?")
-      data = {}
+      data = {'level' => severity}
       if msg.respond_to?(:to_hash)
         data.merge!(msg.to_hash)
       else

--- a/lib/logstasher/log_subscriber.rb
+++ b/lib/logstasher/log_subscriber.rb
@@ -15,8 +15,8 @@ module LogStasher
 
       tags = ['request']
       tags.push('exception') if payload[:exception]
-      event = LogStash::Event.new(data.merge('source' => LogStasher.source, 'tags' => tags))
-      LogStasher.logger << event.to_json + "\n"
+
+      LogStasher.logger << LogStasher.build_logstash_event(data, tags).to_json + "\n"
     end
 
     def redirect_to(event)
@@ -122,8 +122,7 @@ module LogStasher
 
     def process_event(event, tags)
       data = LogStasher.request_context.merge(extract_metadata(event.payload))
-      event = LogStash::Event.new(data.merge('source' => LogStasher.source, 'tags' => tags))
-      logger << event.to_json + "\n"
+      logger << LogStasher.build_logstash_event(data, tags).to_json + "\n"
     end
 
     def extract_metadata(payload)

--- a/spec/lib/logstasher_spec.rb
+++ b/spec/lib/logstasher_spec.rb
@@ -200,12 +200,12 @@ describe LogStasher do
     end
     it 'adds to log with specified level' do
       expect(logger).to receive(:send).with('warn?').and_return(true)
-      expect(logger).to receive(:<<).with('{"level":"warn","message":"WARNING","source":"unknown","tags":["log"],"@timestamp":"1970-01-01T00:00:00Z","@version":"1"}'+"\n")
+      expect(logger).to receive(:<<).with('{"level":"warn","message":"WARNING","source":"unknown","tags":["log"],"@timestamp":"'+$test_timestamp+'","@version":"1"}'+"\n")
       LogStasher.log('warn', 'WARNING')
     end
     it 'logs a message responding to to_hash with keys at top level' do
       expect(logger).to receive(:send).with('warn?').and_return(true)
-      expect(logger).to receive(:<<).with('{"level":"warn","foo":"bar","baz":"quux","source":"unknown","tags":["log"],"@timestamp":"1970-01-01T00:00:00Z","@version":"1"}'+"\n")
+      expect(logger).to receive(:<<).with('{"level":"warn","foo":"bar","baz":"quux","source":"unknown","tags":["log"],"@timestamp":"'+$test_timestamp+'","@version":"1"}'+"\n")
       LogStasher.log('warn', {foo: 'bar', baz: 'quux'})
     end
     context 'with a source specified' do
@@ -214,7 +214,7 @@ describe LogStasher do
       end
       it 'sets the correct source' do
         expect(logger).to receive(:send).with('warn?').and_return(true)
-        expect(logger).to receive(:<<).with('{"level":"warn","message":"WARNING","source":"foo","tags":["log"],"@timestamp":"1970-01-01T00:00:00Z","@version":"1"}'+"\n")
+        expect(logger).to receive(:<<).with('{"level":"warn","message":"WARNING","source":"foo","tags":["log"],"@timestamp":"'+$test_timestamp+'","@version":"1"}'+"\n")
         LogStasher.log('warn', 'WARNING')
       end
     end

--- a/spec/lib/logstasher_spec.rb
+++ b/spec/lib/logstasher_spec.rb
@@ -200,12 +200,12 @@ describe LogStasher do
     end
     it 'adds to log with specified level' do
       expect(logger).to receive(:send).with('warn?').and_return(true)
-      expect(logger).to receive(:<<).with('{"message":"WARNING","source":"unknown","tags":["log"],"@timestamp":"1970-01-01T00:00:00Z","@version":"1"}'+"\n")
+      expect(logger).to receive(:<<).with('{"level":"warn","message":"WARNING","source":"unknown","tags":["log"],"@timestamp":"1970-01-01T00:00:00Z","@version":"1"}'+"\n")
       LogStasher.log('warn', 'WARNING')
     end
     it 'logs a message responding to to_hash with keys at top level' do
       expect(logger).to receive(:send).with('warn?').and_return(true)
-      expect(logger).to receive(:<<).with('{"foo":"bar","baz":"quux","source":"unknown","tags":["log"],"@timestamp":"1970-01-01T00:00:00Z","@version":"1"}'+"\n")
+      expect(logger).to receive(:<<).with('{"level":"warn","foo":"bar","baz":"quux","source":"unknown","tags":["log"],"@timestamp":"1970-01-01T00:00:00Z","@version":"1"}'+"\n")
       LogStasher.log('warn', {foo: 'bar', baz: 'quux'})
     end
     context 'with a source specified' do
@@ -214,7 +214,7 @@ describe LogStasher do
       end
       it 'sets the correct source' do
         expect(logger).to receive(:send).with('warn?').and_return(true)
-        expect(logger).to receive(:<<).with('{"message":"WARNING","source":"foo","tags":["log"],"@timestamp":"1970-01-01T00:00:00Z","@version":"1"}'+"\n")
+        expect(logger).to receive(:<<).with('{"level":"warn","message":"WARNING","source":"foo","tags":["log"],"@timestamp":"1970-01-01T00:00:00Z","@version":"1"}'+"\n")
         LogStasher.log('warn', 'WARNING')
       end
     end

--- a/spec/lib/logstasher_spec.rb
+++ b/spec/lib/logstasher_spec.rb
@@ -200,8 +200,13 @@ describe LogStasher do
     end
     it 'adds to log with specified level' do
       expect(logger).to receive(:send).with('warn?').and_return(true)
-      expect(logger).to receive(:<<).with("{\"@source\":\"unknown\",\"@fields\":{\"message\":\"WARNING\",\"level\":\"warn\"},\"@tags\":[\"log\"],\"@timestamp\":\"#{$test_timestamp}\",\"@version\":\"1\"}\n")
+      expect(logger).to receive(:<<).with('{"message":"WARNING","source":"unknown","tags":["log"],"@timestamp":"1970-01-01T00:00:00Z","@version":"1"}'+"\n")
       LogStasher.log('warn', 'WARNING')
+    end
+    it 'logs a message responding to to_hash with keys at top level' do
+      expect(logger).to receive(:send).with('warn?').and_return(true)
+      expect(logger).to receive(:<<).with('{"foo":"bar","baz":"quux","source":"unknown","tags":["log"],"@timestamp":"1970-01-01T00:00:00Z","@version":"1"}'+"\n")
+      LogStasher.log('warn', {foo: 'bar', baz: 'quux'})
     end
     context 'with a source specified' do
       before :each do
@@ -209,7 +214,7 @@ describe LogStasher do
       end
       it 'sets the correct source' do
         expect(logger).to receive(:send).with('warn?').and_return(true)
-        expect(logger).to receive(:<<).with("{\"@source\":\"foo\",\"@fields\":{\"message\":\"WARNING\",\"level\":\"warn\"},\"@tags\":[\"log\"],\"@timestamp\":\"#{$test_timestamp}\",\"@version\":\"1\"}\n")
+        expect(logger).to receive(:<<).with('{"message":"WARNING","source":"foo","tags":["log"],"@timestamp":"1970-01-01T00:00:00Z","@version":"1"}'+"\n")
         LogStasher.log('warn', 'WARNING')
       end
     end


### PR DESCRIPTION
This change was made for most log messages via 99f4d9d1aa3dba7b0dc567c282ef65ed5ab491ea, but for some reason the change to [lib/logstasher.rb](https://github.com/shadabahmed/logstasher/blob/682cd2e446f617cf21cff8146b3690a42633648b/lib/logstasher.rb#L116) in shadabahmed/logstasher#54 was not included. As a result, calls to `LogStasher.log` continued to use the old format. (Messages contained top-level `@source` instead of `source`, for example.)

To DRY up the code and maybe prevent similar problems in the future, creation of `LogStash::Event` instances is now centralized in the `LogStasher.build_logstash_event` method.

Additional feature: Any message which responds to `to_hash` now has its keys added to the top-level of the message, rather than being nested under `message`.