### PR TITLE
allow specification of tags in LogStasher.log

### DIFF
--- a/lib/logstasher.rb
+++ b/lib/logstasher.rb
@@ -14,7 +14,7 @@ module LogStasher
   STORE_KEY = :logstasher_data
   REQUEST_CONTEXT_KEY = :logstasher_request_context
 
-  attr_accessor :logger, :logger_path, :enabled, :log_controller_parameters, :source, :backtrace,
+  attr_accessor :logger, :logger_path, :enabled, :log_controller_parameters, :source, :backtrace, 
     :delayed_jobs_support, :controller_monkey_patch
   # Setting the default to 'unknown' to define the default behaviour
   @source = 'unknown'
@@ -93,7 +93,7 @@ module LogStasher
 
   def setup(config)
     # Path instrumentation class to insert our hook
-    if (! config.controller_monkey_patch && config.controller_monkey_patch != false) || config.controller_monkey_patch == true
+    if (! config.controller_monkey_patch && config.controller_monkey_patch != false) || config.controller_monkey_patch == true 
       require 'logstasher/rails_ext/action_controller/metal/instrumentation'
     end
     self.delayed_plugin(config)

--- a/spec/lib/logstasher_spec.rb
+++ b/spec/lib/logstasher_spec.rb
@@ -115,11 +115,11 @@ describe LogStasher do
       expect(LogStasher::ActionView::LogSubscriber).to receive(:attach_to).with(:action_view)
       expect(LogStasher).to receive(:require).with('logstash-event')
     end
-    
+
   end
   shared_examples 'setup' do
     let(:logstasher_source) { nil }
-    let(:logstasher_config) { double(:enabled => true, 
+    let(:logstasher_config) { double(:enabled => true,
                                      :logger => logger, :log_level => 'warn', :log_controller_parameters => nil,
                                      :source => logstasher_source, :logger_path => logger_path, :backtrace => true,
                                      :controller_monkey_patch => true, :delayed_jobs_support => false) }
@@ -239,25 +239,35 @@ describe LogStasher do
     let(:logger) { double() }
     before do
       LogStasher.logger = logger
+      allow(logger).to receive(:send).with('warn?').and_return(true)
       allow(Time).to receive_messages(:now => Time.at(0))
       allow_message_expectations_on_nil
     end
     it 'adds to log with specified level' do
-      expect(logger).to receive(:send).with('warn?').and_return(true)
       expect(logger).to receive(:<<).with('{"level":"warn","message":"WARNING","source":"unknown","tags":["log"],"@timestamp":"'+$test_timestamp+'","@version":"1"}'+"\n")
       LogStasher.log('warn', 'WARNING')
     end
     it 'logs a message responding to to_hash with keys at top level' do
-      expect(logger).to receive(:send).with('warn?').and_return(true)
       expect(logger).to receive(:<<).with('{"level":"warn","foo":"bar","baz":"quux","source":"unknown","tags":["log"],"@timestamp":"'+$test_timestamp+'","@version":"1"}'+"\n")
       LogStasher.log('warn', {foo: 'bar', baz: 'quux'})
+    end
+    it 'logs a string message and additional structured data' do
+      expect(logger).to receive(:<<).with('{"level":"warn","message":"main message","other":"data","source":"unknown","tags":["log"],"@timestamp":"'+$test_timestamp+'","@version":"1"}'+"\n")
+      LogStasher.log('warn', 'main message', {other:'data'})
+    end
+    it 'allows specification of tags' do
+      expect(logger).to receive(:<<).with('{"level":"warn","message":"main message","other":"data","source":"unknown","tags":["a","b"],"@timestamp":"'+$test_timestamp+'","@version":"1"}'+"\n")
+      LogStasher.log('warn', 'main message', {other:'data', tags:['a', 'b']})
+    end
+    it 'allows a single tag as a string' do
+      expect(logger).to receive(:<<).with('{"level":"warn","message":"main message","other":"data","source":"unknown","tags":["one"],"@timestamp":"'+$test_timestamp+'","@version":"1"}'+"\n")
+      LogStasher.log('warn', 'main message', {other:'data', tags:'one'})
     end
     context 'with a source specified' do
       before :each do
         LogStasher.source = 'foo'
       end
       it 'sets the correct source' do
-        expect(logger).to receive(:send).with('warn?').and_return(true)
         expect(logger).to receive(:<<).with('{"level":"warn","message":"WARNING","source":"foo","tags":["log"],"@timestamp":"'+$test_timestamp+'","@version":"1"}'+"\n")
         LogStasher.log('warn', 'WARNING')
       end
@@ -268,8 +278,8 @@ describe LogStasher do
     describe ".#{severity}" do
       let(:message) { "This is a #{severity} message" }
       it 'should log with specified level' do
-        expect(LogStasher).to receive(:log).with(severity.to_sym, message)
-        LogStasher.send(severity, message )
+        expect(LogStasher).to receive(:log).with(severity.to_sym, message, {})
+        LogStasher.send(severity, message)
       end
     end
   end
@@ -309,7 +319,7 @@ describe LogStasher do
       end
     end
   end
-  
+
   describe ".enabled?" do
     it "returns false if not enabled" do
       expect(LogStasher).to receive(:enabled).and_return(false)
@@ -319,12 +329,12 @@ describe LogStasher do
       expect(LogStasher.enabled?).to be true
     end
   end
-  
+
   describe ".called_as_rake?" do
     it "returns false if not called as rake" do
       expect(LogStasher.called_as_rake?).to be false
     end
-    
+
     it "returns true if called as rake" do
       expect(File).to receive(:basename).with($0).and_return('rake')
       expect(LogStasher.called_as_rake?).to be true
@@ -335,7 +345,7 @@ describe LogStasher do
     it "does not touch request_context if not called as rake" do
       expect(LogStasher.request_context).to be_empty
     end
-    
+
     it "sets request_context accordingly if called as rake" do
       expect(LogStasher).to receive(:called_as_rake?).and_return(true)
       expect(Rake.application).to receive(:top_level_tasks).and_return(['mytask'])
@@ -349,7 +359,7 @@ describe LogStasher do
     it "returns false if not called as console" do
       expect(LogStasher.called_as_console?).to be false
     end
-    
+
     it "returns true if called as rake" do
       require 'rails/commands/console'
       expect(LogStasher.called_as_console?).to be true
@@ -360,7 +370,7 @@ describe LogStasher do
     it "does not touch request_context if not called as console" do
       expect(LogStasher.request_context).to be_empty
     end
-    
+
     it "sets request_context accordingly if called as console" do
       require 'rails/commands/console'
       expect(LogStasher).to receive(:called_as_console?).and_return(true)

--- a/spec/lib/logstasher_spec.rb
+++ b/spec/lib/logstasher_spec.rb
@@ -115,11 +115,11 @@ describe LogStasher do
       expect(LogStasher::ActionView::LogSubscriber).to receive(:attach_to).with(:action_view)
       expect(LogStasher).to receive(:require).with('logstash-event')
     end
-
+    
   end
   shared_examples 'setup' do
     let(:logstasher_source) { nil }
-    let(:logstasher_config) { double(:enabled => true,
+    let(:logstasher_config) { double(:enabled => true, 
                                      :logger => logger, :log_level => 'warn', :log_controller_parameters => nil,
                                      :source => logstasher_source, :logger_path => logger_path, :backtrace => true,
                                      :controller_monkey_patch => true, :delayed_jobs_support => false) }
@@ -319,7 +319,7 @@ describe LogStasher do
       end
     end
   end
-
+  
   describe ".enabled?" do
     it "returns false if not enabled" do
       expect(LogStasher).to receive(:enabled).and_return(false)
@@ -329,12 +329,12 @@ describe LogStasher do
       expect(LogStasher.enabled?).to be true
     end
   end
-
+  
   describe ".called_as_rake?" do
     it "returns false if not called as rake" do
       expect(LogStasher.called_as_rake?).to be false
     end
-
+    
     it "returns true if called as rake" do
       expect(File).to receive(:basename).with($0).and_return('rake')
       expect(LogStasher.called_as_rake?).to be true
@@ -345,7 +345,7 @@ describe LogStasher do
     it "does not touch request_context if not called as rake" do
       expect(LogStasher.request_context).to be_empty
     end
-
+    
     it "sets request_context accordingly if called as rake" do
       expect(LogStasher).to receive(:called_as_rake?).and_return(true)
       expect(Rake.application).to receive(:top_level_tasks).and_return(['mytask'])
@@ -359,7 +359,7 @@ describe LogStasher do
     it "returns false if not called as console" do
       expect(LogStasher.called_as_console?).to be false
     end
-
+    
     it "returns true if called as rake" do
       require 'rails/commands/console'
       expect(LogStasher.called_as_console?).to be true
@@ -370,7 +370,7 @@ describe LogStasher do
     it "does not touch request_context if not called as console" do
       expect(LogStasher.request_context).to be_empty
     end
-
+    
     it "sets request_context accordingly if called as console" do
       require 'rails/commands/console'
       expect(LogStasher).to receive(:called_as_console?).and_return(true)


### PR DESCRIPTION
before this calls always added the hard-coded tag 'log'. (This is retained as a default if no other tags are specified.)

Examples:

```ruby
LogStasher.info("message")
LogStasher.info("message", tags:"tag1")
LogStasher.info("message", tags:["tag1", "tag2"])
LogStasher.info("message", timing:1234)
LogStasher.info(custom1:"yes", custom2:"no")
```