### PR TITLE
activerecord log subscriber should not add null log entries for SCHEMA queries

### DIFF
--- a/lib/logstasher/active_record/log_subscriber.rb
+++ b/lib/logstasher/active_record/log_subscriber.rb
@@ -6,7 +6,9 @@ module LogStasher
     class LogSubscriber < ::ActiveRecord::LogSubscriber
       def identity(event)
         if logger
-          logger << logstash_event(event).to_json + "\n"
+          if log_event = logstash_event(event)
+            logger << log_event.to_json + "\n"
+          end
         end
       end
       alias :sql :identity

--- a/lib/logstasher/active_record/log_subscriber.rb
+++ b/lib/logstasher/active_record/log_subscriber.rb
@@ -31,7 +31,7 @@ module LogStasher
         data.merge! extract_custom_fields(data)
 
         tags = ['request']
-        tags.push('exception') if payload[:exception]
+        tags.push('exception') if data[:exception]
         LogStasher.build_logstash_event(data, tags)
       end
 


### PR DESCRIPTION
Logstasher::ActiveRecord::LogSubscriber#identity can receive events like:
```
<ActiveSupport::Notifications::Event:0x007fe9e6297de0
  @name="sql.active_record",
  @payload={
    :sql=>"SHOW TABLES ",
    :name=>"SCHEMA",
    :connection_id=>70321253222500,
    :statement_name=>nil,
    :binds=>[]
  },
  @time="2015-10-26T13:44:41.962-05:00",
  @transaction_id="adb86898a0b273024cba",
  @end="2015-10-26T13:44:41.962-05:00",
  @children=[],
  @duration=nil>
```

[`logstash_event`](https://github.com/shadabahmed/logstasher/blob/4e3f2ce6eb199f6756fa0b65ea6fd8d365def216/lib/logstasher/active_record/log_subscriber.rb#L24) would return a nil because `event.payload[:name] == 'SCHEMA'`, and this nil was then logged by [`identity`](https://github.com/shadabahmed/logstasher/blob/4e3f2ce6eb199f6756fa0b65ea6fd8d365def216/lib/logstasher/active_record/log_subscriber.rb#L9).

In one local application, I saw 5 `null` log entries added every time I started rails. The patch attached here silences them.

cc @MarcGrimme