### PR TITLE
Remove the active record subscriber default from rails.

### DIFF
--- a/lib/logstasher.rb
+++ b/lib/logstasher.rb
@@ -30,6 +30,8 @@ module LogStasher
           unsubscribe(:action_controller, subscriber)
         when 'ActionMailer::LogSubscriber'
           unsubscribe(:action_mailer, subscriber)
+        when 'ActiveRecord::LogSubscriber'
+          unsubscribe(:active_record, subscriber)
       end
     end
   end


### PR DESCRIPTION
By default ActiveRecord adds itself to the list of log subscribers. It is not see cause in production those locks are disabled by default. Still there are people wanting to have those logs even in production. To be consistent LogStasher::suppress_app_logs should also remove this subscriber. This patch does this.