### PR TITLE
bug fixed: custom_fields is empty

### DIFF
--- a/lib/logstasher/action_view/log_subscriber.rb
+++ b/lib/logstasher/action_view/log_subscriber.rb
@@ -62,7 +62,6 @@ module LogStasher
 
       def extract_custom_fields(data)
         custom_fields = (!LogStasher.custom_fields.empty? && data.extract!(*LogStasher.custom_fields)) || {}
-        LogStasher.custom_fields.clear
         custom_fields
       end
     end


### PR DESCRIPTION
When one request insert mutil logs (e.g. render_template.action_view logs), 
custom fields will be empty