### PR TITLE
YAML config, enable/disable log_subscriber's, 1 bug fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,14 +81,14 @@ In your Gemfile:
 Has the same optional fields as the `<environment>.rb`
 
     development:
-      enabled: false
+      enabled: true
       controller_enabled: true
       mailer_enabled: false
       record_enabled: true
       view_enabled: true
       suppress_app_log: false
     production:
-      enabled: false
+      enabled: true
       controller_enabled: true
       mailer_enabled: true
       record_enabled: false

--- a/README.md
+++ b/README.md
@@ -78,22 +78,20 @@ In your Gemfile:
 
 ## Optionally use config/logstasher.yml (overrides `<environment>.rb`)
 
-Has the same optional fields as the `<environment>.rb`
+Has the same optional fields as the `<environment>.rb`. You can specify common configurations that are then overriden by environment specific configurations:
 
+    controller_enabled: true
+    mailer_enabled: false
+    record_enabled: false
+    view_enabled: true
+    suppress_app_log: false
     development:
       enabled: true
-      controller_enabled: true
-      mailer_enabled: false
       record_enabled: true
-      view_enabled: true
-      suppress_app_log: false
     production:
       enabled: true
-      controller_enabled: true
       mailer_enabled: true
-      record_enabled: false
       view_enabled: false
-      suppress_app_log: false
 
 ## Logging params hash
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,12 @@ In your Gemfile:
     # Enable the logstasher logs for the current environment
     config.logstasher.enabled = true
 
+    # Each of the following lines are optional. If you want to selectively disable log subscribers.
+    config.logstasher.controller_enabled = false
+    config.logstasher.mailer_enabled = false
+    config.logstasher.record_enabled = false
+    config.logstasher.view_enabled = false
+
     # This line is optional if you do not want to suppress app logs in your <environment>.log
     config.logstasher.suppress_app_log = false
 
@@ -66,9 +72,28 @@ In your Gemfile:
 
     # This line is optional if you do not want to log the backtrace of exceptions
     config.logstasher.backtrace = false
-    
+
     # This line is optional, defaults to log/logstasher_<environment>.log
     config.logstasher.logger_path = 'log/logstasher.log'
+
+## Optionally use config/logstasher.yml (overrides `<environment>.rb`)
+
+Has the same optional fields as the `<environment>.rb`
+
+    development:
+      enabled: false
+      controller_enabled: true
+      mailer_enabled: false
+      record_enabled: true
+      view_enabled: true
+      suppress_app_log: false
+    production:
+      enabled: false
+      controller_enabled: true
+      mailer_enabled: true
+      record_enabled: false
+      view_enabled: false
+      suppress_app_log: false
 
 ## Logging params hash
 

--- a/lib/logstasher.rb
+++ b/lib/logstasher.rb
@@ -14,7 +14,7 @@ module LogStasher
   STORE_KEY = :logstasher_data
   REQUEST_CONTEXT_KEY = :logstasher_request_context
 
-  attr_accessor :logger, :logger_path, :enabled, :log_controller_parameters, :source, :backtrace, 
+  attr_accessor :logger, :logger_path, :enabled, :log_controller_parameters, :source, :backtrace,
     :controller_monkey_patch
   # Setting the default to 'unknown' to define the default behaviour
   @source = 'unknown'
@@ -87,15 +87,15 @@ module LogStasher
   def setup_before(config)
     require 'logstash-event'
     self.enabled = config.enabled
-    LogStasher::ActiveSupport::LogSubscriber.attach_to :action_controller
-    LogStasher::ActiveSupport::MailerLogSubscriber.attach_to :action_mailer
-    LogStasher::ActiveRecord::LogSubscriber.attach_to :active_record
-    LogStasher::ActionView::LogSubscriber.attach_to :action_view
+    LogStasher::ActiveSupport::LogSubscriber.attach_to :action_controller if config.controller_enabled
+    LogStasher::ActiveSupport::MailerLogSubscriber.attach_to :action_mailer if config.mailer_enabled
+    LogStasher::ActiveRecord::LogSubscriber.attach_to :active_record if config.record_enabled
+    LogStasher::ActionView::LogSubscriber.attach_to :action_view if config.view_enabled
   end
 
   def setup(config)
     # Path instrumentation class to insert our hook
-    if (! config.controller_monkey_patch && config.controller_monkey_patch != false) || config.controller_monkey_patch == true 
+    if (! config.controller_monkey_patch && config.controller_monkey_patch != false) || config.controller_monkey_patch == true
       require 'logstasher/rails_ext/action_controller/metal/instrumentation'
     end
     self.suppress_app_logs(config)

--- a/lib/logstasher/action_view/log_subscriber.rb
+++ b/lib/logstasher/action_view/log_subscriber.rb
@@ -62,7 +62,6 @@ module LogStasher
 
       def extract_custom_fields(data)
         custom_fields = (!LogStasher.custom_fields.empty? && data.extract!(*LogStasher.custom_fields)) || {}
-        LogStasher.custom_fields.clear
         custom_fields
       end
     end

--- a/lib/logstasher/active_record/log_subscriber.rb
+++ b/lib/logstasher/active_record/log_subscriber.rb
@@ -21,7 +21,6 @@ module LogStasher
       def logstash_event(event)
         data = event.payload
 
-        return unless logger.debug?
         return if 'SCHEMA' == data[:name]
 
         data.merge! runtimes(event)

--- a/lib/logstasher/active_record/log_subscriber.rb
+++ b/lib/logstasher/active_record/log_subscriber.rb
@@ -52,7 +52,6 @@ module LogStasher
 
       def extract_custom_fields(data)
         custom_fields = (!LogStasher.custom_fields.empty? && data.extract!(*LogStasher.custom_fields)) || {}
-        LogStasher.custom_fields.clear
         custom_fields
       end
     end

--- a/lib/logstasher/active_support/log_subscriber.rb
+++ b/lib/logstasher/active_support/log_subscriber.rb
@@ -98,7 +98,6 @@ module LogStasher
 
       def extract_custom_fields(payload)
         custom_fields = (!LogStasher.custom_fields.empty? && payload.extract!(*LogStasher.custom_fields)) || {}
-        LogStasher.custom_fields.clear
         custom_fields
       end
     end

--- a/lib/logstasher/railtie.rb
+++ b/lib/logstasher/railtie.rb
@@ -15,26 +15,18 @@ module LogStasher
     config.logstasher.view_enabled = true
 
     # Try loading the config/logstasher.yml if present
-    env = Rails.env || 'development'
+    env = Rails.env.to_sym || :development
     config_file = File.expand_path "./config/logstasher.yml"
 
     # Load and ERB templating of YAML files
-    LOGSTASHER = File.exists?(config_file) ? YAML.load(ERB.new(File.read(config_file)).result)[env].symbolize_keys : nil
+    LOGSTASHER = File.exists?(config_file) ? YAML.load(ERB.new(File.read(config_file)).result).symbolize_keys : nil
 
     initializer :logstasher, :before => :load_config_initializers do |app|
       if LOGSTASHER.present?
-        # Enable the logstasher logs for the current environment
-        app.config.logstasher.enabled = LOGSTASHER[:enabled] if LOGSTASHER.key? :enabled
-        app.config.logstasher.controller_enabled = LOGSTASHER[:controller_enabled] if LOGSTASHER.key? :controller_enabled
-        app.config.logstasher.mailer_enabled = LOGSTASHER[:mailer_enabled] if LOGSTASHER.key? :mailer_enabled
-        app.config.logstasher.record_enabled = LOGSTASHER[:record_enabled] if LOGSTASHER.key? :record_enabled
-        app.config.logstasher.view_enabled = LOGSTASHER[:view_enabled] if LOGSTASHER.key? :view_enabled
-        #
-        # # This line is optional if you do not want to suppress app logs in your <environment>.log
-        app.config.logstasher.suppress_app_log = LOGSTASHER[:suppress_app_log] if LOGSTASHER.key? :suppress_app_log
-        #
-        # # This line is optional, it allows you to set a custom value for the @source field of the log event
-        app.config.logstasher.source = LOGSTASHER[:source].present? ? LOGSTASHER[:source] : IPSocket.getaddress(Socket.gethostname)
+        # process common configs
+        LogStasher.process_config(app.config.logstasher, LOGSTASHER)
+        # process environment specific configs
+        LogStasher.process_config(app.config.logstasher, LOGSTASHER[env].symbolize_keys) if LOGSTASHER.key? env
       end
 
       app.config.action_dispatch.rack_cache[:verbose] = false if app.config.action_dispatch.rack_cache
@@ -46,5 +38,23 @@ module LogStasher
         LogStasher.setup(config.logstasher) if config.logstasher.enabled
       end
     end
+  end
+
+  def process_config(config, yml_config)
+    # Enable the logstasher logs for the current environment
+    config.enabled = yml_config[:enabled] if yml_config.key? :enabled
+    config.controller_enabled = yml_config[:controller_enabled] if yml_config.key? :controller_enabled
+    config.mailer_enabled = yml_config[:mailer_enabled] if yml_config.key? :mailer_enabled
+    config.record_enabled = yml_config[:record_enabled] if yml_config.key? :record_enabled
+    config.view_enabled = yml_config[:view_enabled] if yml_config.key? :view_enabled
+    #
+    # # This line is optional if you do not want to suppress app logs in your <environment>.log
+    config.suppress_app_log = yml_config[:suppress_app_log] if yml_config.key? :suppress_app_log
+    #
+    # # This line is optional, it allows you to set a custom value for the @source field of the log event
+    config.source = yml_config[:source].present? ? yml_config[:source] : IPSocket.getaddress(Socket.gethostname)
+
+    config.backtrace = yml_config[:backtrace] if yml_config.key? :backtrace
+    config.logger_path = yml_config[:logger_path] if yml_config.key? :logger_path
   end
 end

--- a/lib/logstasher/railtie.rb
+++ b/lib/logstasher/railtie.rb
@@ -1,13 +1,42 @@
 require 'rails/railtie'
 require 'action_view/log_subscriber'
 require 'action_controller/log_subscriber'
+require 'socket'
 
 module LogStasher
   class Railtie < Rails::Railtie
     config.logstasher = ::ActiveSupport::OrderedOptions.new
     config.logstasher.enabled = false
 
+    # Set up the default logging options
+    config.logstasher.controller_enabled = true
+    config.logstasher.mailer_enabled = true
+    config.logstasher.record_enabled = false
+    config.logstasher.view_enabled = true
+
+    # Try loading the config/logstasher.yml if present
+    env = Rails.env || 'development'
+    config_file = File.expand_path "./config/logstasher.yml"
+
+    # Load and ERB templating of YAML files
+    LOGSTASHER = File.exists?(config_file) ? YAML.load(ERB.new(File.read(config_file)).result)[env].symbolize_keys : nil
+
     initializer :logstasher, :before => :load_config_initializers do |app|
+      if LOGSTASHER.present?
+        # Enable the logstasher logs for the current environment
+        app.config.logstasher.enabled = LOGSTASHER[:enabled] if LOGSTASHER.key? :enabled
+        app.config.logstasher.controller_enabled = LOGSTASHER[:controller_enabled] if LOGSTASHER.key? :controller_enabled
+        app.config.logstasher.mailer_enabled = LOGSTASHER[:mailer_enabled] if LOGSTASHER.key? :mailer_enabled
+        app.config.logstasher.record_enabled = LOGSTASHER[:record_enabled] if LOGSTASHER.key? :record_enabled
+        app.config.logstasher.view_enabled = LOGSTASHER[:view_enabled] if LOGSTASHER.key? :view_enabled
+        #
+        # # This line is optional if you do not want to suppress app logs in your <environment>.log
+        app.config.logstasher.suppress_app_log = LOGSTASHER[:suppress_app_log] if LOGSTASHER.key? :suppress_app_log
+        #
+        # # This line is optional, it allows you to set a custom value for the @source field of the log event
+        app.config.logstasher.source = LOGSTASHER[:source].present? ? LOGSTASHER[:source] : IPSocket.getaddress(Socket.gethostname)
+      end
+
       app.config.action_dispatch.rack_cache[:verbose] = false if app.config.action_dispatch.rack_cache
       LogStasher.setup_before(app.config.logstasher) if app.config.logstasher.enabled
     end

--- a/sample_logstash_configurations/logstasher.yml.sample
+++ b/sample_logstash_configurations/logstasher.yml.sample
@@ -1,0 +1,7 @@
+development:
+  enabled: true
+  controller_enabled: true
+  mailer_enabled: false
+  record_enabled: false
+  view_enabled: false
+  suppress_app_log: false

--- a/sample_logstash_configurations/logstasher.yml.sample
+++ b/sample_logstash_configurations/logstasher.yml.sample
@@ -1,7 +1,13 @@
+controller_enabled: true
+mailer_enabled: false
+record_enabled: false
+view_enabled: true
+suppress_app_log: false
 development:
   enabled: true
-  controller_enabled: true
-  mailer_enabled: false
-  record_enabled: false
+  record_enabled: true
+production:
+  enabled: true
+  mailer_enabled: true
   view_enabled: false
-  suppress_app_log: false
+


### PR DESCRIPTION
First, thanks for this gem. With the changes below we're using this in our production environment to get some really useful information to Kibana.

There are 3 changes in this PR:
1. You can now optionally configure logstasher in a YAML file config/logstasher.yml
2. You can enable or disable each log_subscriber type individually
3. There is a fix for custom_fields being cleared after their first use. The line LogStasher.custom_fields.clear in the extract_custom_fields method of the view, record and support log_subscriber's