### PR TITLE
[Fixes #109] Fixed memory leak in custom_fields.

### DIFF
--- a/lib/logstasher/action_view/log_subscriber.rb
+++ b/lib/logstasher/action_view/log_subscriber.rb
@@ -1,9 +1,12 @@
 require 'active_support/notifications'
 require 'action_view/log_subscriber'
+require 'logstasher/custom_fields'
 
 module LogStasher
   module ActionView
     class LogSubscriber < ::ActionView::LogSubscriber
+      include CustomFields::LogSubscriber
+
       def render_template(event)
         logstash_event(event)
       end
@@ -57,12 +60,6 @@ module LogStasher
           runtimes[name] = runtime.to_f.round(2) if runtime
           runtimes
         end
-
-      end
-
-      def extract_custom_fields(data)
-        custom_fields = (!LogStasher.custom_fields.empty? && data.extract!(*LogStasher.custom_fields)) || {}
-        custom_fields
       end
     end
   end

--- a/lib/logstasher/active_record/log_subscriber.rb
+++ b/lib/logstasher/active_record/log_subscriber.rb
@@ -1,9 +1,12 @@
 require 'active_support/notifications'
 require 'active_record/log_subscriber'
+require 'logstasher/custom_fields'
 
 module LogStasher
   module ActiveRecord
     class LogSubscriber < ::ActiveRecord::LogSubscriber
+      include CustomFields::LogSubscriber
+
       def identity(event)
         lsevent = logstash_event(event)
         if logger && lsevent
@@ -47,11 +50,6 @@ module LogStasher
 
       def extract_sql(data)
         { sql: data[:sql].squeeze(' ') }
-      end
-
-      def extract_custom_fields(data)
-        custom_fields = (!LogStasher.custom_fields.empty? && data.extract!(*LogStasher.custom_fields)) || {}
-        custom_fields
       end
     end
   end

--- a/lib/logstasher/active_support/log_subscriber.rb
+++ b/lib/logstasher/active_support/log_subscriber.rb
@@ -1,9 +1,12 @@
 require 'active_support/core_ext/class/attribute'
 require 'active_support/log_subscriber'
+require 'logstasher/custom_fields'
 
 module LogStasher
   module ActiveSupport
     class LogSubscriber < ::ActiveSupport::LogSubscriber
+      include CustomFields::LogSubscriber
+
       def process_action(event)
         payload = event.payload
 
@@ -94,11 +97,6 @@ module LogStasher
         else
           {}
         end
-      end
-
-      def extract_custom_fields(payload)
-        custom_fields = (!LogStasher.custom_fields.empty? && payload.extract!(*LogStasher.custom_fields)) || {}
-        custom_fields
       end
     end
   end

--- a/lib/logstasher/custom_fields.rb
+++ b/lib/logstasher/custom_fields.rb
@@ -1,0 +1,25 @@
+module LogStasher
+  module CustomFields
+    module LogSubscriber
+      def extract_custom_fields(data)
+        (!CustomFields.custom_fields.empty? && data.extract!(*CustomFields.custom_fields)) || {}
+      end
+    end
+    
+    def self.clear
+      Thread.current[:logstasher_custom_fields] = []
+    end
+
+    def self.add(*fields)
+      custom_fields.concat(fields).uniq!
+    end
+
+    def self.custom_fields
+      Thread.current[:logstasher_custom_fields] ||= []
+    end
+
+    def self.custom_fields=(val)
+      Thread.current[:logstasher_custom_fields] = val
+    end
+  end
+end

--- a/lib/logstasher/rails_ext/action_controller/base.rb
+++ b/lib/logstasher/rails_ext/action_controller/base.rb
@@ -7,6 +7,7 @@ module LogStasher
         LogStasher.add_default_fields_to_request_context(request)
 
         super(*args)
+        LogStasher::CustomFields.clear
       end
       
       private
@@ -23,7 +24,7 @@ module LogStasher
           logtasher_add_custom_fields_to_payload(payload)
           after_keys = payload.keys
           # Store all extra keys added to payload hash in payload itself. This is a thread safe way
-          LogStasher.custom_fields += after_keys - before_keys
+          LogStasher::CustomFields.add(*(after_keys - before_keys))
         end
 
         payload[:status] = response.status

--- a/lib/logstasher/rails_ext/action_controller/metal/instrumentation.rb
+++ b/lib/logstasher/rails_ext/action_controller/metal/instrumentation.rb
@@ -42,10 +42,10 @@ module ActionController
         LogStasher.request_context.each do |key, value|
           payload[key] = value
         end
+        LogStasher::CustomFields.clear
         result
       end
     end
     alias :logstasher_process_action :process_action
-
   end
 end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+require 'logstasher/rails_ext/action_controller/base'
+
+describe ActionController::Base do
+  before do
+    class MyController < ActionController::Base
+      include LogStasher::ActionController::Instrumentation
+
+      def index(*args)
+        render text: 'OK'
+      end
+    end
+  end
+
+  describe 'process_action' do
+    subject { MyController.new }
+
+    before :each do
+      subject.request = ActionDispatch::TestRequest.new
+      subject.response = ActionDispatch::TestResponse.new
+
+      LogStasher.add_custom_fields_to_request_context do |fields|
+        fields[:some_field] = 'value'
+      end
+
+      ActiveSupport::Notifications.subscribe('process_action.action_controller') do |_, _, _, _, payload|
+        @payload = payload
+      end
+    end
+
+    2.times do
+      it 'stays constant with custom_fields' do
+        subject.process_action(:index)
+        expect(Thread.current[:logstasher_custom_fields]).to eq []
+      end
+    end
+    after :each do
+      expect(@payload[:some_field]).to eq('value')
+    end
+  end
+end

--- a/spec/lib/logstasher/active_support/log_subscriber_spec.rb
+++ b/spec/lib/logstasher/active_support/log_subscriber_spec.rb
@@ -15,7 +15,7 @@ describe LogStasher::ActiveSupport::LogSubscriber do
   before do
     LogStasher.logger = logger
     LogStasher.log_controller_parameters = true
-    LogStasher.custom_fields = []
+    LogStasher::CustomFields.custom_fields = []
   end
   after do
     LogStasher.log_controller_parameters = false
@@ -171,7 +171,7 @@ describe LogStasher::ActiveSupport::LogSubscriber do
       LogStasher.add_custom_fields do |payload|
         payload[:user] = 'user'
       end
-      LogStasher.custom_fields += [:user]
+      LogStasher::CustomFields.custom_fields += [:user]
     end
 
     it "should add the custom data to the output" do

--- a/spec/lib/logstasher/custom_fields_spec.rb
+++ b/spec/lib/logstasher/custom_fields_spec.rb
@@ -1,0 +1,11 @@
+require 'logstasher/custom_fields'
+
+describe LogStasher::CustomFields do
+  describe '#add' do
+    before(:each) { LogStasher::CustomFields.add(:test, :test2) }
+    after(:each) { LogStasher::CustomFields.custom_fields = [] }
+    it 'returns the stored var in current thread' do
+      expect(Thread.current[:logstasher_custom_fields]).to eq [:test, :test2]
+    end
+  end
+end

--- a/spec/lib/logstasher/instrumentation_spec.rb
+++ b/spec/lib/logstasher/instrumentation_spec.rb
@@ -10,7 +10,6 @@ describe ActionController::Base do
     end
   end
   before :each do
-
     subject.request = ActionDispatch::TestRequest.new
     subject.response = ActionDispatch::TestResponse.new
 

--- a/spec/lib/logstasher_spec.rb
+++ b/spec/lib/logstasher_spec.rb
@@ -48,24 +48,24 @@ describe LogStasher do
     let(:payload) { {:params => params} }
     let(:request) { double(:params => params, :remote_ip => '10.0.0.1', :env => {})}
     after do
-      LogStasher.custom_fields = []
+      LogStasher::CustomFields.clear
       LogStasher.log_controller_parameters = false
     end
     it 'appends default parameters to payload' do
       LogStasher.log_controller_parameters = true
-      LogStasher.custom_fields = []
+      LogStasher::CustomFields.clear
       LogStasher.add_default_fields_to_payload(payload, request)
       expect(payload[:ip]).to eq '10.0.0.1'
       expect(payload[:route]).to eq 'test#action'
       expect(payload[:parameters]).to eq 'a' => '1', 'b' => 2
-      expect(LogStasher.custom_fields).to eq [:ip, :route, :request_id, :parameters]
+      expect(LogStasher::CustomFields.custom_fields).to eq [:ip, :route, :request_id, :parameters]
     end
 
     it 'does not include parameters when not configured to' do
-      LogStasher.custom_fields = []
+      LogStasher::CustomFields.clear
       LogStasher.add_default_fields_to_payload(payload, request)
       expect(payload).to_not have_key(:parameters)
-      expect(LogStasher.custom_fields).to eq [:ip, :route, :request_id]
+      expect(LogStasher::CustomFields.custom_fields).to eq [:ip, :route, :request_id]
     end
   end
 
@@ -114,7 +114,6 @@ describe LogStasher do
       expect(LogStasher::ActionView::LogSubscriber).to receive(:attach_to).with(:action_view)
       expect(LogStasher).to receive(:require).with('logstash-event')
     end
-
   end
   shared_examples 'setup' do
     let(:logstasher_source) { nil }
@@ -139,7 +138,7 @@ describe LogStasher do
       LogStasher.setup(config.logstasher)
       expect(LogStasher.source).to eq (logstasher_source || 'unknown')
       expect(LogStasher).to be_enabled
-      expect(LogStasher.custom_fields).to be_empty
+      expect(LogStasher::CustomFields.custom_fields).to be_empty
       expect(LogStasher.log_controller_parameters).to eq false
       expect(LogStasher.request_context).to be_empty
     end
@@ -204,20 +203,6 @@ describe LogStasher do
     end
   end
 
-  describe '.appended_params' do
-    it 'returns the stored var in current thread' do
-      Thread.current[:logstasher_custom_fields] = :test
-      expect(LogStasher.custom_fields).to eq :test
-    end
-  end
-
-  describe '.appended_params=' do
-    it 'returns the stored var in current thread' do
-      LogStasher.custom_fields = :test
-      expect(Thread.current[:logstasher_custom_fields]).to eq :test
-    end
-  end
-
   describe '.log' do
     let(:logger) { double() }
     before do
@@ -226,6 +211,7 @@ describe LogStasher do
       allow(Time).to receive_messages(:now => Time.at(0))
       allow_message_expectations_on_nil
     end
+    after { LogStasher::CustomFields.clear }
     it 'adds to log with specified level' do
       expect(logger).to receive(:<<).with('{"level":"warn","message":"WARNING","source":"unknown","tags":["log"],"@timestamp":"'+$test_timestamp+'","@version":"1"}'+"\n")
       LogStasher.log('warn', 'WARNING')
@@ -279,7 +265,7 @@ describe LogStasher do
   end
 
   describe ".watch" do
-    before(:each) { LogStasher.custom_fields = [] }
+    before(:each) { LogStasher::CustomFields.custom_fields = [] }
 
     it "subscribes to the required event" do
       expect(ActiveSupport::Notifications).to receive(:subscribe).with('event_name')


### PR DESCRIPTION
Done:
1. Fixed memory leak in custom_fields
2. Moved out custom_fields in it's own area and don't DRY the log_subscribersribers.

Fixes #109 