### PR TITLE
Fix missed update to LogStasher.custom_fields.

### DIFF
--- a/lib/logstasher/rails_ext/action_controller/metal/instrumentation.rb
+++ b/lib/logstasher/rails_ext/action_controller/metal/instrumentation.rb
@@ -28,7 +28,7 @@ module ActionController
           logtasher_add_custom_fields_to_payload(raw_payload)
           after_keys = raw_payload.keys
           # Store all extra keys added to payload hash in payload itself. This is a thread safe way
-          LogStasher.custom_fields += after_keys - before_keys
+          LogStasher::CustomFields.add(*(after_keys - before_keys))
         end
 
         result = super


### PR DESCRIPTION
The call to LogStasher.custom_fields (which no longer exists) causes a fatal error.  Update the call to match the change in LogStasher::ActionController::Instrumentation
