### PR TITLE
Update default version of Rails to one compatible with the current LogStasher code

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source "https://rubygems.org"
 gemspec
 
 group :test do
-  gem 'rails', "~> #{ENV["RAILS_VERSION"] || "3.2.0"}"
+  gem 'rails', "~> #{ENV["RAILS_VERSION"] || "4.2.0"}"
   gem 'rb-fsevent', '~> 0.9'
   gem 'rcov', :platforms => :mri_18
   gem 'redis', :require => false


### PR DESCRIPTION
Default version was 3.2.x.  LogStasher currently requires >= 4.0.0.  Set to 4.2.x as that's the latest supported 4.x.x version of Rails.
