### PR TITLE
[Parly #114] Fixes a regression found in instrumentation with customer_fields

### DIFF
--- a/lib/logstasher/rails_ext/action_controller/metal/instrumentation.rb
+++ b/lib/logstasher/rails_ext/action_controller/metal/instrumentation.rb
@@ -28,7 +28,7 @@ module ActionController
           logtasher_add_custom_fields_to_payload(raw_payload)
           after_keys = raw_payload.keys
           # Store all extra keys added to payload hash in payload itself. This is a thread safe way
-          LogStasher.custom_fields += after_keys - before_keys
+          LogStasher::CustomFields.add(*(after_keys - before_keys))
         end
 
         result = super


### PR DESCRIPTION
Fixes a regression found in instrumentation that still uses the old version of tempering with custom_fields.

Closes issue raised in #114 / #115 