### PR TITLE
Adding documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,14 @@ if LogStasher.enabled?
     # If you are using custom instrumentation, just add it to logstasher custom fields
     LogStasher.custom_fields << :myapi_runtime
   end
+
+  LogStasher.add_custom_fields_to_request_context do |fields|
+    # This block is run in application_controller context,
+    # so you have access to all controller methods
+    # You can log custom request fields using this block
+    fields[:user] = current_user && current_user.mail
+    fields[:site] = request.path =~ /^\/api/ ? 'api' : 'user'
+  end
 end
 ```
 ## Logging ActionMailer events


### PR DESCRIPTION
Adding missing documentation on how to add custom fields to request logs.

As adding custom fields in add_custom_fields call, does not log it to request params.

Let me know if i need to change something.