### PR TITLE
Allow event's fields renaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,9 @@ bin/logstash -f quickstart.conf
 All versions require Rails 3.0.x and higher and Ruby 1.9.2+. Tested on Rails 4 and Ruby 2.0
 
 ## Development
+ - Install dependencies:
+   export RAILS_VERSION=4.2
+   bundle install --without guard --path=${BUNDLE_PATH:-vendor/bundle}
  - Run tests - `rake`
  - Generate test coverage report - `rake coverage`. Coverage report path - coverage/index.html
 

--- a/README.md
+++ b/README.md
@@ -82,6 +82,12 @@ config.logstasher.backtrace = false
 
 # This line is optional, defaults to log/logstasher_<environment>.log
 config.logstasher.logger_path = 'log/logstasher.log'
+
+# This line is optional, loaded only if the value is truthy
+config.field_renaming = {
+    old_field_name => new_field_name,
+}
+
 ```
 
 ## Optionally use config/logstasher.yml (overrides `<environment>.rb`)

--- a/lib/logstasher.rb
+++ b/lib/logstasher.rb
@@ -17,7 +17,7 @@ module LogStasher
   REQUEST_CONTEXT_KEY = :logstasher_request_context
 
   attr_accessor :logger, :logger_path, :enabled, :log_controller_parameters, :source, :backtrace,
-    :controller_monkey_patch
+    :controller_monkey_patch, :field_renaming
   # Setting the default to 'unknown' to define the default behaviour
   @source = 'unknown'
   # By default log the backtrace of exceptions
@@ -112,6 +112,7 @@ module LogStasher
     self.backtrace = !! config.backtrace unless config.backtrace.nil?
     self.set_data_for_rake
     self.set_data_for_console
+    self.field_renaming = Hash(config.field_renaming)
   end
 
   def set_data_for_rake
@@ -177,6 +178,9 @@ module LogStasher
   end
 
   def build_logstash_event(data, tags)
+    field_renaming.each do |old_name, new_name|
+        data[new_name] = data.delete(old_name) if data.key?(old_name)
+    end
     ::LogStash::Event.new(data.merge('source' => self.source, 'tags' => tags))
   end
 

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -11,6 +11,7 @@ describe ActionController::Base do
       #LogStasher::ActiveRecord::LogSubscriber.attach_to :active_record
       LogStasher::ActionView::LogSubscriber.attach_to :action_view
       #LogStasher::ActiveJob::LogSubscriber.attach_to :active_job
+      LogStasher.field_renaming = {}
     end
 
     before :each do

--- a/spec/lib/logstasher_spec.rb
+++ b/spec/lib/logstasher_spec.rb
@@ -3,6 +3,10 @@ require 'active_record'
 require 'rake'
 
 describe LogStasher do
+  before :each do
+    LogStasher.field_renaming = {}
+  end
+
   describe "when removing Rails' log subscribers" do
     after do
       ActionController::LogSubscriber.attach_to :action_controller
@@ -108,6 +112,16 @@ describe LogStasher do
     end
   end
 
+  describe ".build_logstash_event" do
+    it 'renames fields' do
+        LogStasher.field_renaming = { field_a: 'other_name_a', field_b: 'some_name_b' }
+        data = {field_a: 111, field_b:222}
+        renamed = LogStasher.build_logstash_event(data,{})
+        expect(renamed['other_name_a']).to eq(111)
+        expect(renamed['some_name_b']).to eq(222)
+    end
+  end
+
   shared_examples 'setup_before' do
     let(:logstasher_source) { nil }
     let(:logstasher_config) { double(:enabled => true) }
@@ -135,7 +149,7 @@ describe LogStasher do
                                      :logger => logger, :log_level => 'warn', :log_controller_parameters => nil,
                                      :source => logstasher_source, :logger_path => logger_path, :backtrace => true,
                                      :controller_monkey_patch => true, :controller_enabled => true,
-                                     :mailer_enabled => true, :record_enabled => false, :view_enabled => true, :job_enabled => true) }
+                                     :mailer_enabled => true, :record_enabled => false, :view_enabled => true, :job_enabled => true, :field_renaming => {})}
     let(:config) { double(:logstasher => logstasher_config) }
     let(:app) { double(:config => config) }
     before do


### PR DESCRIPTION
Added 'field_renaming' configuration option

We used this feature to let Elastic/FileBeat ship logs directly to ES instead to Logstash and the to ES.

Comments are welcome,
Yarden