### PR TITLE
Add backtrace filter option

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,9 @@ config.logstasher.source = 'your.arbitrary.source'
 # This line is optional if you do not want to log the backtrace of exceptions
 config.logstasher.backtrace = false
 
+# This line is optional if you want to filter backtrace, it will just log result of callable as backtrace
+config.logstasher.backtrace_filter = ->(bt){ Rails.backtrace_cleaner.clean(bt) }
+
 # This line is optional, defaults to log/logstasher_<environment>.log
 config.logstasher.logger_path = 'log/logstasher.log'
 

--- a/lib/logstasher.rb
+++ b/lib/logstasher.rb
@@ -17,7 +17,7 @@ module LogStasher
   REQUEST_CONTEXT_KEY = :logstasher_request_context
 
   attr_accessor :logger, :logger_path, :enabled, :log_controller_parameters, :source, :backtrace,
-    :controller_monkey_patch, :field_renaming
+    :controller_monkey_patch, :field_renaming, :backtrace_filter
   # Setting the default to 'unknown' to define the default behaviour
   @source = 'unknown'
   # By default log the backtrace of exceptions
@@ -110,6 +110,7 @@ module LogStasher
     self.source = config.source unless config.source.nil?
     self.log_controller_parameters = !! config.log_controller_parameters
     self.backtrace = !! config.backtrace unless config.backtrace.nil?
+    self.backtrace_filter = config.backtrace_filter
     self.set_data_for_rake
     self.set_data_for_console
     self.field_renaming = Hash(config.field_renaming)

--- a/lib/logstasher/active_support/log_subscriber.rb
+++ b/lib/logstasher/active_support/log_subscriber.rb
@@ -88,11 +88,17 @@ module LogStasher
         if payload[:exception]
           exception, message = payload[:exception]
           status = ::ActionDispatch::ExceptionWrapper.status_code_for_exception(exception)
-          if LogStasher.backtrace
-            backtrace = $!.backtrace.join("\n")
+
+          backtrace = if LogStasher.backtrace
+            if LogStasher.backtrace_filter.respond_to?(:call)
+              LogStasher.backtrace_filter.call($!.backtrace).join("\n")
+            else
+              $!.backtrace.join("\n")
+            end
           else
-            backtrace = $!.backtrace.first
+            $!.backtrace.first
           end
+
           message = "#{exception}\n#{message}\n#{backtrace}"
           { :status => status, :error => message }
         else

--- a/spec/lib/logstasher_spec.rb
+++ b/spec/lib/logstasher_spec.rb
@@ -147,7 +147,7 @@ describe LogStasher do
     let(:logstasher_source) { nil }
     let(:logstasher_config) { double(:enabled => true,
                                      :logger => logger, :log_level => 'warn', :log_controller_parameters => nil,
-                                     :source => logstasher_source, :logger_path => logger_path, :backtrace => true,
+                                     :source => logstasher_source, :logger_path => logger_path, :backtrace => true, :backtrace_filter => false,
                                      :controller_monkey_patch => true, :controller_enabled => true,
                                      :mailer_enabled => true, :record_enabled => false, :view_enabled => true, :job_enabled => true, :field_renaming => {})}
     let(:config) { double(:logstasher => logstasher_config) }


### PR DESCRIPTION
Many times, when you work with complex framework like Rails you have a ton of backtrace lines that just meaningless for you.
This addition allows flexible filtering of backtrace.