### PR TITLE
Allow not rails(or actually not ActiveRecord/ActiveJob/ActionView) apps using this gem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ Gemfile.lock
 pkg/*
 .idea
 .ruby-version
+vendor
+coverage

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ group :test do
   gem 'rb-fsevent', '~> 0.9'
   gem 'rcov', :platforms => :mri_18
   gem 'redis', :require => false
-  gem 'simplecov', :platforms => :mri_19, :require => false
+  gem 'simplecov', :platforms => [:mri_19, :mri_20, :mri_21, :mri_22, :mri_23], :require => false
 end
 
 group :guard do

--- a/lib/logstasher.rb
+++ b/lib/logstasher.rb
@@ -1,9 +1,9 @@
 require 'logstasher/version'
 require 'logstasher/active_support/log_subscriber'
 require 'logstasher/active_support/mailer_log_subscriber'
-require 'logstasher/active_record/log_subscriber'
-require 'logstasher/action_view/log_subscriber'
-require 'logstasher/active_job/log_subscriber'
+require 'logstasher/active_record/log_subscriber' if defined?(ActiveRecord)
+require 'logstasher/action_view/log_subscriber' if defined?(ActionView)
+require 'logstasher/active_job/log_subscriber' if defined?(ActiveJob)
 require 'logstasher/rails_ext/action_controller/base'
 require 'logstasher/custom_fields'
 require 'request_store'

--- a/logstasher.gemspec
+++ b/logstasher.gemspec
@@ -14,9 +14,9 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'logstash-event', '~> 1.2.0'
   s.add_runtime_dependency 'request_store'
   s.add_runtime_dependency 'activesupport', '>= 4.0'
-  s.add_runtime_dependency 'activerecord', '>= 4.0'
 
   s.add_development_dependency('rspec', '>= 2.14')
   s.add_development_dependency('bundler', '>= 1.0.0')
   s.add_development_dependency('rails', '>= 4.0')
+  s.add_development_dependency('activerecord', '>= 4.0')
 end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -1,6 +1,5 @@
 require 'spec_helper'
 require 'logstasher/rails_ext/action_controller/base'
-require 'active_record'
 
 describe ActionController::Base do
   shared_examples "controller.process_action" do

--- a/spec/lib/logstasher/action_view/log_subscriber_spec.rb
+++ b/spec/lib/logstasher/action_view/log_subscriber_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'logstasher/action_view/log_subscriber'
 
 describe LogStasher::ActionView::LogSubscriber do
   let(:log_output) {StringIO.new}

--- a/spec/lib/logstasher/active_job/log_subscriber_spec.rb
+++ b/spec/lib/logstasher/active_job/log_subscriber_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'logstasher/active_job/log_subscriber'
 
 describe LogStasher::ActiveJob::LogSubscriber do
   require 'active_job'

--- a/spec/lib/logstasher/active_record/log_subscriber_spec.rb
+++ b/spec/lib/logstasher/active_record/log_subscriber_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'logstasher/active_record/log_subscriber'
 
 describe LogStasher::ActiveRecord::LogSubscriber do
   let(:log_output) {StringIO.new}

--- a/spec/lib/logstasher_spec.rb
+++ b/spec/lib/logstasher_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
-require 'active_record'
 require 'rake'
+require 'logstash-event'
 
 describe LogStasher do
   before :each do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,7 +10,7 @@ if ENV['COVERAGE']
   end
 end
 
-# Modify load path so you can require 'ogstasher directly.
+# Modify load path so you can require 'logstasher directly.
 $LOAD_PATH.unshift(File.expand_path('../../lib', __FILE__))
 
 require 'rubygems'
@@ -27,25 +27,6 @@ Dir[File.join("./spec/support/**/*.rb")].each { |f| require f }
 
 # Set Rails environment as test
 ENV['RAILS_ENV'] = 'test'
-
-require 'action_pack'
-require 'action_controller'
-require 'logstasher'
-require 'active_support/notifications'
-require 'active_support/core_ext/string'
-require 'active_support/log_subscriber'
-require 'action_controller/log_subscriber'
-require 'action_view/log_subscriber'
-require 'active_support/core_ext/hash/except'
-require 'active_support/core_ext/hash/indifferent_access'
-require 'active_support/core_ext/hash/slice'
-require 'active_support/core_ext/string'
-require 'active_support/core_ext/time/zones'
-require 'abstract_controller/base'
-require 'action_mailer'
-require 'logger'
-require 'logstash-event'
-
 
 $test_timestamp = case Rails.version
 when /^3\./


### PR DESCRIPTION
This gem is very Rails centric but there are apps that might not need to have the ActiveRecord/ActionView/ActiveJob. So the lib should be ready for it. 
That's why I added the `defined?(...)` definitions like:

```
require 'logstasher/active_record/log_subscriber' if defined?(ActiveRecord)
require 'logstasher/action_view/log_subscriber' if defined?(ActionView)
require 'logstasher/active_job/log_subscriber' if defined?(ActiveJob)
```
in `lib/logstasher.rb` file.

Thanks to this I was able to remove **activerecord** from gem dependencies into development dependency. Plus I sorted out the list of dependencies in `spec_helper` and other spec files. While specs are still green.

And I was able to make the coverage also work for other ruby versions than `1.9` but also all next versions after that one + added some new valid ignores to `.gitignore`. 