### PR TITLE
Fix default value of source option

### DIFF
--- a/lib/logstasher/railtie.rb
+++ b/lib/logstasher/railtie.rb
@@ -4,43 +4,6 @@ require 'action_controller/log_subscriber'
 require 'socket'
 
 module LogStasher
-  class Railtie < Rails::Railtie
-    config.logstasher = ::ActiveSupport::OrderedOptions.new
-    config.logstasher.enabled = false
-
-    # Set up the default logging options
-    config.logstasher.controller_enabled = true
-    config.logstasher.mailer_enabled = true
-    config.logstasher.record_enabled = false
-    config.logstasher.view_enabled = true
-    config.logstasher.job_enabled = true
-
-    # Try loading the config/logstasher.yml if present
-    env = Rails.env.to_sym || :development
-    config_file = File.expand_path "./config/logstasher.yml"
-
-    # Load and ERB templating of YAML files
-    LOGSTASHER = File.exists?(config_file) ? YAML.load(ERB.new(File.read(config_file)).result).symbolize_keys : nil
-
-    initializer :logstasher, :before => :load_config_initializers do |app|
-      if LOGSTASHER.present?
-        # process common configs
-        LogStasher.process_config(app.config.logstasher, LOGSTASHER)
-        # process environment specific configs
-        LogStasher.process_config(app.config.logstasher, LOGSTASHER[env].symbolize_keys) if LOGSTASHER.key? env
-      end
-
-      app.config.action_dispatch.rack_cache[:verbose] = false if app.config.action_dispatch.rack_cache
-      LogStasher.setup_before(app.config.logstasher) if app.config.logstasher.enabled
-    end
-
-    initializer :logstasher do
-      config.after_initialize do
-        LogStasher.setup(config.logstasher) if config.logstasher.enabled
-      end
-    end
-  end
-
   def default_source
     case RUBY_PLATFORM
     when /darwin/
@@ -69,10 +32,48 @@ module LogStasher
     config.suppress_app_log = yml_config[:suppress_app_log] if yml_config.key? :suppress_app_log
 
     # This line is optional, it allows you to set a custom value for the @source field of the log event
-    config.source = yml_config.key?(:source) ? yml_config[:source] : default_source
+    config.source = yml_config[:source] if yml_config.key? :source
 
     config.backtrace = yml_config[:backtrace] if yml_config.key? :backtrace
     config.logger_path = yml_config[:logger_path] if yml_config.key? :logger_path
     config.log_level = yml_config[:log_level] if yml_config.key? :log_level
+  end
+
+  class Railtie < Rails::Railtie
+    config.logstasher = ::ActiveSupport::OrderedOptions.new
+    config.logstasher.enabled = false
+
+    # Set up the default logging options
+    config.logstasher.controller_enabled = true
+    config.logstasher.mailer_enabled = true
+    config.logstasher.record_enabled = false
+    config.logstasher.view_enabled = true
+    config.logstasher.job_enabled = true
+    config.logstasher.source = LogStasher.default_source
+
+    # Try loading the config/logstasher.yml if present
+    env = Rails.env.to_sym || :development
+    config_file = File.expand_path "./config/logstasher.yml"
+
+    # Load and ERB templating of YAML files
+    LOGSTASHER = File.exists?(config_file) ? YAML.load(ERB.new(File.read(config_file)).result).symbolize_keys : nil
+
+    initializer :logstasher, :before => :load_config_initializers do |app|
+      if LOGSTASHER.present?
+        # process common configs
+        LogStasher.process_config(app.config.logstasher, LOGSTASHER)
+        # process environment specific configs
+        LogStasher.process_config(app.config.logstasher, LOGSTASHER[env].symbolize_keys) if LOGSTASHER.key? env
+      end
+
+      app.config.action_dispatch.rack_cache[:verbose] = false if app.config.action_dispatch.rack_cache
+      LogStasher.setup_before(app.config.logstasher) if app.config.logstasher.enabled
+    end
+
+    initializer :logstasher do
+      config.after_initialize do
+        LogStasher.setup(config.logstasher) if config.logstasher.enabled
+      end
+    end
   end
 end


### PR DESCRIPTION
# Configuration

``` yaml
log_level: :info
source: "hoge"
controller_enabled: true
mailer_enabled: false
record_enabled: false
job_enabled: false
view_enabled: true
suppress_app_log: false
development:
  enabled: true
  record_enabled: true
production:
  enabled: true
  mailer_enabled: true
  view_enabled: false
```

# Expected behavior

* The source value is applied even if it is not specified in a environment section of the yaml file

```ruby
[1] pry(main)> Rails.application.config.logstasher
=> {:enabled=>true,
 :controller_enabled=>true,
 :mailer_enabled=>false,
 :record_enabled=>true,
 :view_enabled=>true,
 :job_enabled=>false,
 :source=>"hoge",
 :suppress_app_log=>false,
 :log_level=>:info}
```

# Actual behavior(v1.2.1)

* The source value is always override by default value if it is not specified in a environment section of the yaml file

```ruby
[1] pry(main)> Rails.application.config.logstasher
=> {:enabled=>true,
 :controller_enabled=>true,
 :mailer_enabled=>false,
 :record_enabled=>true,
 :view_enabled=>true,
 :job_enabled=>false,
 :suppress_app_log=>false,
 :source=>"127.0.0.1",
 :log_level=>:info}
```