### PR TITLE
Fix bug in detection of ActiveJob

### DIFF
--- a/lib/logstasher.rb
+++ b/lib/logstasher.rb
@@ -132,7 +132,7 @@ module LogStasher
   end
 
   def has_active_job?
-    Rails::VERSION::MAJOR > 4 || (Rails::VERSION::MAJOR == 4 && Rails::VERSION::MINOR >= 2)
+    defined?(ActiveJob)
   end
 
   def suppress_app_logs(config)

--- a/spec/lib/logstasher_spec.rb
+++ b/spec/lib/logstasher_spec.rb
@@ -363,29 +363,6 @@ describe LogStasher do
     end
   end
 
-  describe '.has_active_job?' do
-    it 'returns false when < Rails 4.2' do
-      stub_const('Rails::VERSION::MAJOR', 4)
-      stub_const('Rails::VERSION::MINOR', 1)
-
-      expect(LogStasher.has_active_job?).to be false
-    end
-
-    it 'returns true when Rails 4.2' do
-      stub_const('Rails::VERSION::MAJOR', 4)
-      stub_const('Rails::VERSION::MINOR', 2)
-
-      expect(LogStasher.has_active_job?).to be true
-    end
-
-    it 'returns true when Rails 5' do
-      stub_const('Rails::VERSION::MAJOR', 5)
-      stub_const('Rails::VERSION::MINOR', 0)
-
-      expect(LogStasher.has_active_job?).to be true
-    end
-  end
-
   describe ".set_data_for_console" do
     it "does not touch request_context if not called as console" do
       expect(LogStasher.request_context).to be_empty


### PR DESCRIPTION
This method currently assumes that when we run Rails 4.2+, ActiveJob is present. This doesn't account for situations where we [explicitly don't include the active job framework][1].

https://github.com/shadabahmed/logstasher/pull/130 added non-Rails support by selectively `requiring` the [ActiveJob integration][2]. This means the `LogStasher::ActiveJob::LogSubscriber` won't be loaded if `ActiveJob` isn't loaded, causing an error.

[1]: https://github.com/alphagov/content-tagger/blob/b0f71be150e26f32d47ff9c69f88fdc768584d9a/config/application.rb#L5-L9
[2]: https://github.com/shadabahmed/logstasher/blob/cc1ee1551123b576734b490faf6bf9e7d24bed51/lib/logstasher.rb#L6