### PR TITLE
Updated ActionController::Instrumentation to allow for multiple libraries to alias process_action method

### DIFF
--- a/lib/logstasher/rails_ext/action_controller/metal/instrumentation.rb
+++ b/lib/logstasher/rails_ext/action_controller/metal/instrumentation.rb
@@ -1,50 +1,52 @@
-module ActionController
-  module Instrumentation
-    alias :orig_process_action :process_action
-    def process_action(*args)
-      raw_payload = {
-          :controller => self.class.name,
-          :action     => self.action_name,
-          :params     => request.filtered_parameters,
-          :format     => request.format.try(:ref),
-          :method     => request.method,
-          :path       => (request.fullpath rescue "unknown")
-      }
+::ActionController::Instrumentation.class_eval do
+  def process_action_with_logstasher(*args)
+    payload = {
+        :controller => self.class.name,
+        :action     => self.action_name,
+        :params     => request.filtered_parameters,
+        :format     => request.format.try(:ref),
+        :method     => request.method,
+        :path       => (request.fullpath rescue "unknown")
+    }
 
-      LogStasher.add_default_fields_to_payload(raw_payload, request)
+    LogStasher.add_default_fields_to_payload(payload, request)
 
-      LogStasher.clear_request_context
-      LogStasher.add_default_fields_to_request_context(request)
+    LogStasher.clear_request_context
+    LogStasher.add_default_fields_to_request_context(request)
 
-      ActiveSupport::Notifications.instrument("start_processing.action_controller", raw_payload.dup)
-
-      ActiveSupport::Notifications.instrument("process_action.action_controller", raw_payload) do |payload|
-        if self.respond_to?(:logstasher_add_custom_fields_to_request_context)
-          logstasher_add_custom_fields_to_request_context(LogStasher.request_context)
-        end
-
-        if self.respond_to?(:logstasher_add_custom_fields_to_payload)
-          before_keys = raw_payload.keys.clone
-          logstasher_add_custom_fields_to_payload(raw_payload)
-          after_keys = raw_payload.keys
-          # Store all extra keys added to payload hash in payload itself. This is a thread safe way
-          LogStasher::CustomFields.add(*(after_keys - before_keys))
-        end
-
-        result = super
-
-        payload[:status] = response.status
-        append_info_to_payload(payload)
-        LogStasher.store.each do |key, value|
-          payload[key] = value
-        end
-
-        LogStasher.request_context.each do |key, value|
-          payload[key] = value
-        end
-        result
-      end
-    end
-    alias :logstasher_process_action :process_action
+    process_action_without_logstasher(*args)
   end
+
+  alias_method :process_action_without_logstasher, :process_action
+  alias_method :process_action, :process_action_with_logstasher
+
+  def append_info_to_payload_with_logstasher(payload)
+    result = append_info_to_payload_without_logstasher(payload)
+
+    if self.respond_to?(:logstasher_add_custom_fields_to_request_context)
+      logstasher_add_custom_fields_to_request_context(LogStasher.request_context)
+    end
+
+    if self.respond_to?(:logstasher_add_custom_fields_to_payload)
+      before_keys = payload.keys.clone
+      logstasher_add_custom_fields_to_payload(payload)
+      after_keys = payload.keys
+      # Store all extra keys added to payload hash in payload itself. This is a thread safe way
+      LogStasher::CustomFields.add(*(after_keys - before_keys))
+    end
+
+    payload[:status] = response.status
+
+    LogStasher.store.each do |key, value|
+      payload[key] = value
+    end
+
+    LogStasher.request_context.each do |key, value|
+      payload[key] = value
+    end
+    result
+  end
+
+  alias_method :append_info_to_payload_without_logstasher, :append_info_to_payload
+  alias_method :append_info_to_payload, :append_info_to_payload_with_logstasher
 end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -32,7 +32,7 @@ describe ActionController::Base do
 
     2.times do |index|
       it 'stays constant with custom_fields' do
-         expect(LogStasher).to receive(:build_logstash_event).with(
+        expect(LogStasher).to receive(:build_logstash_event).with(
           hash_including(identifier: "text template", layout: nil, name: "render_template.action_view", request_id: index, ip: "0.0.0.0", route: "#"), any_args)
         expect(LogStasher).to receive(:build_logstash_event).with(
           hash_including(method: "GET", path: "/", format: :html, controller: nil, action: nil, status: 200, ip: "0.0.0.0", route: "#", request_id: index, some_field: "value"), any_args)

--- a/spec/lib/logstasher/base_instrumentation_spec.rb
+++ b/spec/lib/logstasher/base_instrumentation_spec.rb
@@ -3,10 +3,9 @@ require 'logstasher/rails_ext/action_controller/base'
 
 describe LogStasher::SampleController do
   before do
-    module ActionController              # Revert the monkey patch again
-      module Instrumentation
-        alias :process_action :orig_process_action
-      end
+    # Revert the monkey patch again
+    ::ActionController::Instrumentation.class_eval do
+      alias_method :process_action, :process_action_without_logstasher
     end
   end
 

--- a/spec/lib/logstasher/instrumentation_spec.rb
+++ b/spec/lib/logstasher/instrumentation_spec.rb
@@ -5,10 +5,11 @@ describe ActionController::Base do
   before do
     module ActionController              # Revert the monkey patch again
       module Instrumentation
-        alias :process_action :logstasher_process_action
+        alias :process_action :process_action_with_logstasher
       end
     end
   end
+
   before :each do
     subject.request = ActionDispatch::TestRequest.new
     subject.response = ActionDispatch::TestResponse.new


### PR DESCRIPTION
I ran into an issue integrating DataDog's [ddtrace gem](https://github.com/DataDog/dd-trace-rb) with logstasher and traced it to the monkey patching of the `ActionController::Instrumentation` class, which both gems do. However, Logstasher's didn't allow other gems to patch, so I reorganized it a bit. 

~~One issue I have is that this instrumentation spec is failing https://github.com/shadabahmed/logstasher/blob/master/spec/lib/logstasher/instrumentation_spec.rb#L54, but I'm not sure it's necessary.~~

I'm curious if you've encountered this before and if this makes sense. 
  