### PR TITLE
active_record/log_subscriber: fix SystemStackError on Rails 6

### DIFF
--- a/lib/logstasher/active_record/log_subscriber.rb
+++ b/lib/logstasher/active_record/log_subscriber.rb
@@ -23,9 +23,13 @@ module LogStasher
 
       def logstash_event(event)
         self.class.runtime += event.duration
-        data = event.payload
+        data = event.payload.dup
 
         return if 'SCHEMA' == data[:name]
+
+        # A connection cannot be converted to JSON as it fails with
+        # SystemStackError when running against ActiveSupport JSON patches.
+        data.delete(:connection)
 
         data.merge! runtimes(event)
         data.merge! extract_sql(data)

--- a/lib/logstasher/version.rb
+++ b/lib/logstasher/version.rb
@@ -1,3 +1,3 @@
 module LogStasher
-  VERSION = "1.2.2"
+  VERSION = "1.3.0"
 end

--- a/spec/lib/logstasher/active_record/log_subscriber_spec.rb
+++ b/spec/lib/logstasher/active_record/log_subscriber_spec.rb
@@ -60,6 +60,15 @@ describe LogStasher::ActiveRecord::LogSubscriber do
       subject.identity(event)
       expect(log_output.json['duration']).to eq 0.00
     end
+
+    it "should not contain :connection" do
+      event.payload[:connection] = Object.new
+
+      subject.identity(event)
+      expect(event.payload[:connection]).not_to be_nil
+      expect(log_output.json['connection']).to be_nil
+    end
+
   end
 
   describe "with append_custom_params block specified" do


### PR DESCRIPTION
When running migrations on Rails 6 logstasher tries to log stuff but chokes on
SystemStackError:

```
SystemStackError: stack level too deep
...
/gems/activesupport-6.0.2.2/lib/active_support/core_ext/object/json.rb:172:in `map'
/gems/activesupport-6.0.2.2/lib/active_support/core_ext/object/json.rb:172:in `as_json'"
```

The problem is that Rails 6 started adding `:connection` object to the event
object, and it cannot be dumped to JSON due to the error above, and therefore
making the whole app useless.