### PR TITLE
Rails 6.2 compatibility

### DIFF
--- a/lib/logstasher.rb
+++ b/lib/logstasher.rb
@@ -34,7 +34,7 @@ module LogStasher
           unsubscribe(:action_mailer, subscriber)
         when 'ActiveRecord::LogSubscriber'
           unsubscribe(:active_record, subscriber)
-        when 'ActiveJob::Logging::LogSubscriber'
+        when 'ActiveJob::LogSubscriber'
           unsubscribe(:active_job, subscriber)
       end
     end

--- a/lib/logstasher/active_job/log_subscriber.rb
+++ b/lib/logstasher/active_job/log_subscriber.rb
@@ -1,12 +1,12 @@
 begin
   # `rescue nil` didn't work for some Ruby versions
-  require 'active_job/logging'
+  require 'active_job/log_subscriber'
 rescue LoadError
 end
 
 module LogStasher
   module ActiveJob
-    class LogSubscriber < ::ActiveJob::Logging::LogSubscriber
+    class LogSubscriber < ::ActiveJob::LogSubscriber
 
       def enqueue(event)
         process_event(event, 'enqueue')
@@ -89,4 +89,4 @@ module LogStasher
 
     end
   end
-end if defined?(::ActiveJob::Logging::LogSubscriber)
+end if defined?(::ActiveJob::LogSubscriber)

--- a/spec/lib/logstasher/active_job/log_subscriber_spec.rb
+++ b/spec/lib/logstasher/active_job/log_subscriber_spec.rb
@@ -26,7 +26,7 @@ describe LogStasher::ActiveJob::LogSubscriber do
     LogStasher.request_context[:request_id] = 'foobar123'
 
     # Silence the default logger from spitting out to the console
-    allow_any_instance_of(ActiveJob::Logging::LogSubscriber).to receive(:logger)
+    allow_any_instance_of(ActiveJob::LogSubscriber).to receive(:logger)
       .and_return(double.as_null_object)
   end
 

--- a/spec/lib/logstasher_spec.rb
+++ b/spec/lib/logstasher_spec.rb
@@ -12,7 +12,7 @@ describe LogStasher do
       ActionController::LogSubscriber.attach_to :action_controller
       ActionView::LogSubscriber.attach_to :action_view
       ActionMailer::LogSubscriber.attach_to :action_mailer
-      ActiveJob::Logging::LogSubscriber.attach_to :active_job if LogStasher.has_active_job?
+      ActiveJob::LogSubscriber.attach_to :active_job if LogStasher.has_active_job?
     end
 
     it "should remove subscribers for controller events" do


### PR DESCRIPTION
Fixes `NameError: uninitialized constant LogStasher::ActiveJob` error