### PR TITLE
Filter out connection from log entry to prevent serialization errors

### DIFF
--- a/lib/logstasher/active_record/log_subscriber.rb
+++ b/lib/logstasher/active_record/log_subscriber.rb
@@ -21,9 +21,13 @@ module LogStasher
 
       def logstash_event(event)
         self.class.runtime += event.duration
-        data = event.payload
+        data = event.payload.dup
 
         return if 'SCHEMA' == data[:name]
+
+        # A connection cannot be converted to JSON as it fails with
+        # SystemStackError when running against ActiveSupport JSON patches.
+        data.delete(:connection)
 
         data.merge! runtimes(event)
         data.merge! extract_sql(data)

--- a/spec/lib/logstasher/active_record/log_subscriber_spec.rb
+++ b/spec/lib/logstasher/active_record/log_subscriber_spec.rb
@@ -16,6 +16,7 @@ describe LogStasher::ActiveRecord::LogSubscriber do
   before do
     LogStasher.logger = logger
     LogStasher.log_controller_parameters = true
+    LogStasher.field_renaming = {}
     LogStasher::CustomFields.custom_fields = []
     allow(described_class).to receive(:runtime).and_return(0)
     allow(described_class).to receive(:runtime=)
@@ -61,6 +62,14 @@ describe LogStasher::ActiveRecord::LogSubscriber do
     it 'should include duration time' do
       subject.identity(event)
       expect(log_output.json['duration']).to eq 0.00
+    end
+
+    it "should not contain :connection" do
+      event.payload[:connection] = Object.new
+
+      subject.identity(event)
+      expect(event.payload[:connection]).not_to be_nil
+      expect(log_output.json['connection']).to be_nil
     end
   end
 


### PR DESCRIPTION
@shadabahmed This PR is a more targeted version of https://github.com/shadabahmed/logstasher/pull/151 , isolating the changes @kyrylo made for connection filtering from the earlier runtime PR.  I believe it should be added as we add support for Rails 6.0/6.1

For what it's worth, this all seems to run green under Rails 6.0 (with one warning), so we can just add that to the matrix