### PR TITLE
Initial Rails 6.1 changes in a way that is compatible with Rails 5.2 and 6.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
            rails-version: 5.2
          - ruby-version: 2.7.2
            bundler-version: default
-           rails-version: 6.0
+           rails-version: 6.0.0
          - ruby-version: 2.7.2
            bundler-version: default
            rails-version: 6.1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,7 +38,7 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby-version }}
         bundler: ${{ matrix.bundler-version }} 
-        bundler-cache: true
+        bundler-cache: false
     - name: Install dependencies
       run: bundle install
       env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,12 @@ jobs:
          - ruby-version: 2.7.2
            bundler-version: default
            rails-version: 5.2
-
+         - ruby-version: 2.7.2
+           bundler-version: default
+           rails-version: 6.0
+         - ruby-version: 2.7.2
+           bundler-version: default
+           rails-version: 6.1
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby ${{ matrix.ruby-version }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
            rails-version: 5.2
          - ruby-version: 2.7.2
            bundler-version: default
-           rails-version: 6.0.0
+           rails-version: 6.0.3.4
          - ruby-version: 2.7.2
            bundler-version: default
            rails-version: 6.1

--- a/lib/logstasher.rb
+++ b/lib/logstasher.rb
@@ -38,6 +38,8 @@ module LogStasher
         unsubscribe(:active_record, subscriber)
       when 'ActiveJob::Logging::LogSubscriber'
         unsubscribe(:active_job, subscriber)
+      when 'ActiveJob::LogSubscriber'
+        unsubscribe(:active_job, subscriber)
       end
     end
   end

--- a/lib/logstasher/active_job/log_subscriber.rb
+++ b/lib/logstasher/active_job/log_subscriber.rb
@@ -1,92 +1,99 @@
+subscriber_base = nil
 begin
-  # `rescue nil` didn't work for some Ruby versions
-  require 'active_job/logging'
+  # Rails 6.1.x and post
+  require 'active_job/log_subscriber'
+  subscriber_base = ::ActiveJob::LogSubscriber
 rescue LoadError
+  # Rails 6.0.x and prior
+  begin
+    require 'active_job/logging'
+    subscriber_base = ::ActiveJob::Logging::LogSubscriber
+  rescue LoadError
+  end
 end
 
-if defined?(::ActiveJob::Logging::LogSubscriber)
-  module LogStasher
-    module ActiveJob
-      class LogSubscriber < ::ActiveJob::Logging::LogSubscriber
-        def enqueue(event)
-          process_event(event, 'enqueue')
-        end
+if subscriber_base
+  module LogStasher::ActiveJob
+  end
 
-        def enqueue_at(event)
-          process_event(event, 'enqueue_at')
-        end
+  LogStasher::ActiveJob::LogSubscriber = Class.new(subscriber_base) do
+    def enqueue(event)
+      process_event(event, 'enqueue')
+    end
 
-        def perform(event)
-          process_event(event, 'perform')
+    def enqueue_at(event)
+      process_event(event, 'enqueue_at')
+    end
 
-          # Revert the request id back, in the event that the inline adapter is being used or a
-          # perform_now was used.
-          LogStasher.request_context[:request_id] = Thread.current[:old_request_id]
-          Thread.current[:old_request_id] = nil
-        end
+    def perform(event)
+      process_event(event, 'perform')
 
-        def perform_start(event)
-          # Use the job_id as the request id, so that any custom logging done for a job
-          # shares a request id, and has the job id in each log line.
-          #
-          # It's not being set when the job is enqueued, so enqueuing a job will have it's default
-          # request_id. In a lot of cases, it will be because of a web request.
-          #
-          # Hang onto the old request id, so we can revert after the job is done being performed.
-          Thread.current[:old_request_id] = LogStasher.request_context[:request_id]
-          LogStasher.request_context[:request_id] = event.payload[:job].job_id
+      # Revert the request id back, in the event that the inline adapter is being used or a
+      # perform_now was used.
+      LogStasher.request_context[:request_id] = Thread.current[:old_request_id]
+      Thread.current[:old_request_id] = nil
+    end
 
-          process_event(event, 'perform_start')
-        end
+    def perform_start(event)
+      # Use the job_id as the request id, so that any custom logging done for a job
+      # shares a request id, and has the job id in each log line.
+      #
+      # It's not being set when the job is enqueued, so enqueuing a job will have it's default
+      # request_id. In a lot of cases, it will be because of a web request.
+      #
+      # Hang onto the old request id, so we can revert after the job is done being performed.
+      Thread.current[:old_request_id] = LogStasher.request_context[:request_id]
+      LogStasher.request_context[:request_id] = event.payload[:job].job_id
 
-        def logger
-          LogStasher.logger
-        end
+      process_event(event, 'perform_start')
+    end
 
-        private
+    def logger
+      LogStasher.logger
+    end
 
-        def process_event(event, type)
-          data = extract_metadata(event)
-          data.merge! extract_exception(event)
-          data.merge! extract_scheduled_at(event) if type == 'enqueue_at'
-          data.merge! extract_duration(event) if type == 'perform'
-          data.merge! request_context
+    private
 
-          tags = ['job', type]
-          tags.push('exception') if data[:exception]
-          logger << LogStasher.build_logstash_event(data, tags).to_json + "\n"
-        end
+    def process_event(event, type)
+      data = extract_metadata(event)
+      data.merge! extract_exception(event)
+      data.merge! extract_scheduled_at(event) if type == 'enqueue_at'
+      data.merge! extract_duration(event) if type == 'perform'
+      data.merge! request_context
 
-        def extract_metadata(event)
-          {
-            job_id: event.payload[:job].job_id,
-            queue_name: queue_name(event),
-            job_class: event.payload[:job].class.to_s,
-            job_args: args_info(event.payload[:job])
-          }
-        end
+      tags = ['job', type]
+      tags.push('exception') if data[:exception]
+      logger << LogStasher.build_logstash_event(data, tags).to_json + "\n"
+    end
 
-        def extract_duration(event)
-          { duration: event.duration.to_f.round(2) }
-        end
+    def extract_metadata(event)
+      {
+        job_id: event.payload[:job].job_id,
+        queue_name: queue_name(event),
+        job_class: event.payload[:job].class.to_s,
+        job_args: args_info(event.payload[:job])
+      }
+    end
 
-        def extract_exception(event)
-          event.payload.slice(:exception)
-        end
+    def extract_duration(event)
+      { duration: event.duration.to_f.round(2) }
+    end
 
-        def extract_scheduled_at(event)
-          { scheduled_at: scheduled_at(event) }
-        end
+    def extract_exception(event)
+      event.payload.slice(:exception)
+    end
 
-        def request_context
-          LogStasher.request_context
-        end
+    def extract_scheduled_at(event)
+      { scheduled_at: scheduled_at(event) }
+    end
 
-        # The default args_info makes a string. We need objects to turn into JSON.
-        def args_info(job)
-          job.arguments.map { |arg| arg.try(:to_global_id).try(:to_s) || arg }
-        end
-      end
+    def request_context
+      LogStasher.request_context
+    end
+
+    # The default args_info makes a string. We need objects to turn into JSON.
+    def args_info(job)
+      job.arguments.map { |arg| arg.try(:to_global_id).try(:to_s) || arg }
     end
   end
 end

--- a/lib/logstasher/active_support/mailer_log_subscriber.rb
+++ b/lib/logstasher/active_support/mailer_log_subscriber.rb
@@ -10,6 +10,11 @@ module LogStasher
         process_event(event, %w[mailer deliver])
       end
 
+      # This method will only be invoked on Rails 6.0 and prior.
+      # Starting in Rails 6.0 the receive method was deprecated in
+      # favor of ActionMailbox.  The receive method was removed
+      # from ActionMailer in Rails 6.1, and there doesn't appear to
+      # be corresponding instrumentation for ActionMailbox.
       def receive(event)
         process_event(event, %w[mailer receive])
       end

--- a/logstasher.gemspec
+++ b/logstasher.gemspec
@@ -11,11 +11,11 @@ Gem::Specification.new do |s|
 
   s.files = `git ls-files lib`.split("\n")
 
-  s.add_runtime_dependency 'activesupport', '>= 5.0'
+  s.add_runtime_dependency 'activesupport', '>= 5.2'
   s.add_runtime_dependency 'request_store'
 
-  s.add_development_dependency('activerecord', '>= 5.0')
+  s.add_development_dependency('activerecord', '>= 5.2')
   s.add_development_dependency('bundler', '>= 1.0.0')
-  s.add_development_dependency('rails', '>= 5.0')
+  s.add_development_dependency('rails', '>= 5.2')
   s.add_development_dependency('rspec', '>= 2.14')
 end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -26,6 +26,7 @@ describe ActionController::Base do
       LogStasher.logger = logger
 
       allow(logger).to receive(:<<)
+      allow(logger).to receive(:debug)
       allow(logger).to receive(:info)
     end
 

--- a/spec/lib/logstasher/active_job/log_subscriber_spec.rb
+++ b/spec/lib/logstasher/active_job/log_subscriber_spec.rb
@@ -68,7 +68,7 @@ if LogStasher.has_active_job?
     end
 
     def enqueue_job_with_error
-      if Rails.version < '6.1'
+      if ActiveJob.gem_version.to_s < '6.1'
         enqueue_job_with_error_pre_6_1
       else
         enqueue_job_with_error_6_1

--- a/spec/lib/logstasher/active_job/log_subscriber_spec.rb
+++ b/spec/lib/logstasher/active_job/log_subscriber_spec.rb
@@ -40,8 +40,17 @@ if LogStasher.has_active_job?
       LogStasher.request_context[:request_id] = 'foobar123'
 
       # Silence the default logger from spitting out to the console
-      allow_any_instance_of(ActiveJob::Logging::LogSubscriber).to receive(:logger)
-        .and_return(double.as_null_object)
+      subscriber_base =
+        if defined?(ActiveJob::LogSubscriber)
+          ActiveJob::LogSubscriber
+        elsif defined?(ActiveJob::Logging::LogSubscriber)
+          ActiveJob::Logging::LogSubscriber
+        end
+
+      if subscriber_base
+        allow_any_instance_of(subscriber_base).to receive(:logger)
+          .and_return(double.as_null_object)
+      end
     end
 
     describe '#logger' do

--- a/spec/lib/logstasher/active_record/log_subscriber_spec.rb
+++ b/spec/lib/logstasher/active_record/log_subscriber_spec.rb
@@ -113,7 +113,7 @@ describe LogStasher::ActiveRecord::LogSubscriber do
     end
 
     it 'should increment runtime by event duration' do
-      expect(described_class).to receive(:runtime=).with(be_within(0.01).of(1000.0))
+      expect(described_class).to receive(:runtime=).with(be_within(0.05).of(1000.0))
       subject.identity(event)
     end
   end

--- a/spec/lib/logstasher/active_support/mailer_log_subscriber_spec.rb
+++ b/spec/lib/logstasher/active_support/mailer_log_subscriber_spec.rb
@@ -8,6 +8,8 @@ describe LogStasher::ActiveSupport::MailerLogSubscriber do
       msg
     }
     def log_output.json
+      return '' if string.nil?
+
       JSON.parse!(string.split("\n").last)
     end
     logger

--- a/spec/lib/logstasher/active_support/mailer_log_subscriber_spec.rb
+++ b/spec/lib/logstasher/active_support/mailer_log_subscriber_spec.rb
@@ -41,15 +41,18 @@ describe LogStasher::ActiveSupport::MailerLogSubscriber do
     end
   end
 
-  it 'receive an e-mail' do
-    SampleMailer.receive(message.encoded)
-    log_output.json.tap do |json|
-      expect(json['source']).to eq(LogStasher.source)
-      expect(json['tags']).to eq(%w[mailer receive])
-      expect(json['mailer']).to eq('SampleMailer')
-      expect(json['from']).to eq(['some-dude@example.com'])
-      expect(json['to']).to eq(['some-other-dude@example.com'])
-      expect(json['message_id']).to eq(message.message_id)
+  # Receive functionality was removed from ActionMailer in 6.1.0
+  if ActionMailer.gem_version.to_s < '6.1.0'
+    it 'receives an e-mail' do
+      SampleMailer.receive(message.encoded)
+      log_output.json.tap do |json|
+        expect(json['source']).to eq(LogStasher.source)
+        expect(json['tags']).to eq(%w[mailer receive])
+        expect(json['mailer']).to eq('SampleMailer')
+        expect(json['from']).to eq(['some-dude@example.com'])
+        expect(json['to']).to eq(['some-other-dude@example.com'])
+        expect(json['message_id']).to eq(message.message_id)
+      end
     end
   end
 

--- a/spec/lib/logstasher_spec.rb
+++ b/spec/lib/logstasher_spec.rb
@@ -20,7 +20,13 @@ describe LogStasher do
       ActionMailer::LogSubscriber.attach_to :action_mailer
       if LogStasher.has_active_job?
         require 'active_job'
-        ActiveJob::Logging::LogSubscriber.attach_to :active_job
+        subscriber_base =
+          if defined?(ActiveJob::LogSubscriber)
+            ActiveJob::LogSubscriber
+          elsif defined?(ActiveJob::Logging::LogSubscriber)
+            ActiveJob::Logging::LogSubscriber
+          end
+        subscriber_base.attach_to :active_job if subscriber_base
       end
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,6 +16,7 @@ require 'rubygems'
 # do bundle install instead of ugly load error on require.
 require 'bundler/setup'
 
+require 'active_support'
 require 'active_record'
 require 'active_job'
 require 'action_view'
@@ -42,4 +43,8 @@ RSpec.configure do |config|
   config.filter_run :focus
 
   ActiveJob::Base.queue_adapter = :test
+
+  def assert_nothing_raised(&block)
+    expect(&block).to_not raise_error
+  end
 end


### PR DESCRIPTION
@shadabahmed This is an attempt to incorporate the Rails 6.1 changes so that the code can run in 5.2 and 6.0.

The major shift is in how the LogStasher::ActiveJob::LogSubscriber inheritance is managed.  We use a variable for the parent class, which depends on the version of ActiveJob that is loaded.

This runs green with existing specs on Rails 5.2.x and 6.0.x, and has 6 failures on Rails 6.1.x. Roughly speaking these break down as:

1. ActiveJob - a test helper issue, where perform_enqueued_jobs is asserting no errors, rather than raising the error as in previous versions (https://api.rubyonrails.org/classes/ActiveJob/TestHelper.html#method-i-perform_enqueued_jobs)
2. MailerLogSubscriber - this likely needs an update for Rails 6.1 changes (ActiveMailbox) which are warned about on Rails 6.0.x
3. Integration spec failures on custom fields - Honestly I don't really understand what this spec is supposed to be testing, so I'm at a bit of a loss.