### PR TITLE
Remove all dependency on logstash-event

### DIFF
--- a/lib/logstasher.rb
+++ b/lib/logstasher.rb
@@ -89,7 +89,6 @@ module LogStasher
   end
 
   def setup_before(config)
-    require 'logstash-event'
     self.enabled = config.enabled
     LogStasher::ActiveSupport::LogSubscriber.attach_to :action_controller if config.controller_enabled
     LogStasher::ActiveSupport::MailerLogSubscriber.attach_to :action_mailer if config.mailer_enabled

--- a/lib/logstasher/version.rb
+++ b/lib/logstasher/version.rb
@@ -1,3 +1,3 @@
 module LogStasher
-  VERSION = '2.0.0'.freeze
+  VERSION = '2.0.1'.freeze
 end

--- a/logstasher.gemspec
+++ b/logstasher.gemspec
@@ -12,7 +12,6 @@ Gem::Specification.new do |s|
   s.files = `git ls-files lib`.split("\n")
 
   s.add_runtime_dependency 'activesupport', '>= 5.0'
-  s.add_runtime_dependency 'logstash-event', '~> 1.2.0'
   s.add_runtime_dependency 'request_store'
 
   s.add_development_dependency('activerecord', '>= 5.0')

--- a/spec/lib/logstasher_spec.rb
+++ b/spec/lib/logstasher_spec.rb
@@ -1,6 +1,5 @@
 require 'spec_helper'
 require 'rake'
-require 'logstash-event'
 require 'action_view/log_subscriber'
 
 def console
@@ -153,7 +152,6 @@ describe LogStasher do
       expect(LogStasher::ActiveRecord::LogSubscriber).to receive(:attach_to).with(:active_record)
       expect(LogStasher::ActionView::LogSubscriber).to receive(:attach_to).with(:action_view)
       expect(LogStasher::ActiveJob::LogSubscriber).to receive(:attach_to).with(:active_job)
-      expect(LogStasher).to receive(:require).with('logstash-event')
     end
   end
   shared_examples 'setup' do


### PR DESCRIPTION
This removes dependency on a really old gem `logstash-event` - https://rubygems.org/gems/logstash-event/versions/1.2.02