### PR TITLE
Updated version of the add_backtrace_filter PR

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,9 @@ config.logstasher.source = 'your.arbitrary.source'
 # This line is optional if you do not want to log the backtrace of exceptions
 config.logstasher.backtrace = false
 
+# This line is optional if you want to filter backtrace, it will just log result of callable as backtrace
+config.logstasher.backtrace_filter = ->(bt){ Rails.backtrace_cleaner.clean(bt) }
+
 # This line is optional, defaults to log/logstasher_<environment>.log
 config.logstasher.logger_path = 'log/logstasher.log'
 

--- a/lib/logstasher.rb
+++ b/lib/logstasher.rb
@@ -20,7 +20,7 @@ module LogStasher
   REQUEST_CONTEXT_KEY = :logstasher_request_context
 
   attr_accessor :logger, :logger_path, :enabled, :log_controller_parameters, :source, :backtrace,
-                :controller_monkey_patch, :field_renaming
+                :controller_monkey_patch, :field_renaming, :backtrace_filter
 
   # Setting the default to 'unknown' to define the default behaviour
   @source = 'unknown'
@@ -113,6 +113,7 @@ module LogStasher
     self.source = config.source unless config.source.nil?
     self.log_controller_parameters = !config.log_controller_parameters.nil?
     self.backtrace = !config.backtrace.nil? unless config.backtrace.nil?
+    self.backtrace_filter = config.backtrace_filter
     set_data_for_rake
     set_data_for_console
     self.field_renaming = Hash(config.field_renaming)

--- a/lib/logstasher/active_support/log_subscriber.rb
+++ b/lib/logstasher/active_support/log_subscriber.rb
@@ -86,10 +86,14 @@ module LogStasher
           exception, message = payload[:exception]
           status = ::ActionDispatch::ExceptionWrapper.status_code_for_exception(exception)
           backtrace = if LogStasher.backtrace
-                        $!.backtrace.join("\n")
-                      else
-                        $!.backtrace.first
-                      end
+            if LogStasher.backtrace_filter.respond_to?(:call)
+              LogStasher.backtrace_filter.call($!.backtrace).join("\n")
+            else
+              $!.backtrace.join("\n")
+            end
+          else
+            $!.backtrace.first
+          end
           message = "#{exception}\n#{message}\n#{backtrace}"
           { status: status, error: message }
         else

--- a/spec/lib/logstasher_spec.rb
+++ b/spec/lib/logstasher_spec.rb
@@ -166,7 +166,7 @@ describe LogStasher do
              logger: logger, log_level: 'warn', log_controller_parameters: nil,
              source: logstasher_source, logger_path: logger_path, backtrace: true,
              controller_monkey_patch: true, controller_enabled: true,
-             mailer_enabled: true, record_enabled: false, view_enabled: true, job_enabled: true, field_renaming: {})
+             mailer_enabled: true, record_enabled: false, view_enabled: true, job_enabled: true, field_renaming: {}, backtrace_filter: false)
     end
     let(:config) { double(logstasher: logstasher_config) }
     let(:app) { double(config: config) }


### PR DESCRIPTION
This is an updated/rebased version of PR #129 .  There are no specs that explicitly cover the backtrace_filter functionality, but I don't see any reason it shouldn't work.  I'd recommend adding a spec before merging.