### PR TITLE
Adding allocations to ActionView events

### DIFF
--- a/lib/logstasher/action_view/log_subscriber.rb
+++ b/lib/logstasher/action_view/log_subscriber.rb
@@ -52,7 +52,7 @@ module LogStasher
         {
           name: event.name,
           transaction_id: event.transaction_id,
-          allocations: event.allocations
+          allocations: event.try(:allocations) || 0
         }
       end
 

--- a/lib/logstasher/action_view/log_subscriber.rb
+++ b/lib/logstasher/action_view/log_subscriber.rb
@@ -51,7 +51,8 @@ module LogStasher
       def event_data(event)
         {
           name: event.name,
-          transaction_id: event.transaction_id
+          transaction_id: event.transaction_id,
+          allocations: event.allocations
         }
       end
 

--- a/spec/lib/logstasher/action_view/log_subscriber_spec.rb
+++ b/spec/lib/logstasher/action_view/log_subscriber_spec.rb
@@ -31,7 +31,7 @@ describe LogStasher::ActionView::LogSubscriber do
   describe '.process_action' do
     let(:logger)  { double }
     let(:json)    do
-      '{"identifier":"mytemplate","layout":"mylayout","name":"render_template.action_view","transaction_id":1,"duration":0.0,"request_id":"1","source":"unknown","tags":[],"@timestamp":"1970-01-01T00:00:00.000Z","@version":"1"}' + "\n"
+      '{"identifier":"mytemplate","layout":"mylayout","name":"render_template.action_view","transaction_id":1,"allocations":0,"duration":0.0,"request_id":"1","source":"unknown","tags":[],"@timestamp":"1970-01-01T00:00:00.000Z","@version":"1"}' + "\n"
     end
     before do
       LogStasher.store.clear


### PR DESCRIPTION
Since Rails 6.x, the `ActiveSupport::Notifications::Event` events has an `allocations` method which is available in the default Rails logs.

This PR aims to add this support to the `ActionView` log subscriber.