### PR TITLE
Add Ruby 3.1 to CI and fill out the compatibility matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,19 +19,28 @@ jobs:
     strategy:
       matrix:
          include:
-         - ruby-version: 2.6.6
+         - ruby-version: 2.6
            bundler-version: default
            rails-version: 5.2
-         - ruby-version: 2.7.2
+         - ruby-version: 2.7
            bundler-version: default
            rails-version: 5.2
-         - ruby-version: 2.7.2
+         - ruby-version: 2.6
            bundler-version: default
-           rails-version: 6.0
-         - ruby-version: 2.7.2
+           rails-version: '6.0'
+         - ruby-version: 2.7
+           bundler-version: default
+           rails-version: '6.0'
+         - ruby-version: 2.6
            bundler-version: default
            rails-version: 6.1
-         - ruby-version: 3.0.0
+         - ruby-version: 2.7
+           bundler-version: default
+           rails-version: 6.1
+         - ruby-version: '3.0'
+           bundler-version: default
+           rails-version: 6.1
+         - ruby-version: 3.1
            bundler-version: default
            rails-version: 6.1
     steps:

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,12 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in logstasher.gemspec
 gemspec
 
+if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new("3.1")
+  gem 'net-smtp', require: false
+  gem 'net-imap', require: false
+  gem 'net-pop', require: false
+end
+
 group :test do
   gem 'byebug'
   gem 'rails', "~> #{ENV['RAILS_VERSION'] || '5.2.0'}"


### PR DESCRIPTION
This PR adds Ruby 3.1 to CI and fills out the supported Ruby versions for the listed Rails versions.

It also removes the explicit patch versions, allowing the minor versions to use the latest patch version in CI.

Aside from the workflow changes, the only required change was that the Gemfile be updated to include the net-smtp, net-imap, and net-pop gems when the Ruby version is 3.1 or higher, as these gems are no longer included in Ruby by default.

A follow up PR will work on adding Rails 7 support.