### PR TITLE
Add request object to "process_action.action_controller" payload

### DIFF
--- a/lib/logstasher/rails_ext/action_controller/metal/instrumentation.rb
+++ b/lib/logstasher/rails_ext/action_controller/metal/instrumentation.rb
@@ -7,7 +7,9 @@ module ActionController
       raw_payload = {
         controller: self.class.name,
         action: action_name,
+        request: request,
         params: request.filtered_parameters,
+        headers: request.headers,
         format: request.format.try(:ref),
         method: request.method,
         path: begin


### PR DESCRIPTION
Logstasher re-implements the "process_action.action_controller" notification handler. [As of Rails 7, the handler assumes that there is a request object in the payload](https://github.com/rails/rails/blob/984c3ef2775781d47efa9f541ce570daa2434a80/actionpack/lib/action_controller/metal/instrumentation.rb#L56). The [request object is used by OpenTelementry SDK](https://github.com/open-telemetry/opentelemetry-ruby-contrib/blob/a466ae3b56efd2c25bdd9a39f798fae0eacd7fcb/instrumentation/action_pack/lib/opentelemetry/instrumentation/action_pack/handlers/action_controller.rb#L27) and with it missing causes errors when reporting spans.

```
ERROR -- : OpenTelemetry error: undefined method `env' for nil:NilClass
```

