### PR TITLE
Add ActiveSupport::ExecutionContext controller setting for Rails 7+

### DIFF
--- a/lib/logstasher/rails_ext/action_controller/metal/instrumentation.rb
+++ b/lib/logstasher/rails_ext/action_controller/metal/instrumentation.rb
@@ -4,6 +4,8 @@ module ActionController
   module Instrumentation
     alias orig_process_action process_action
     def process_action(*args)
+      ActiveSupport::ExecutionContext[:controller] = self if Rails.version.to_i >= 7
+
       raw_payload = {
         controller: self.class.name,
         action: action_name,

--- a/spec/lib/logstasher/instrumentation_spec.rb
+++ b/spec/lib/logstasher/instrumentation_spec.rb
@@ -22,6 +22,18 @@ describe ActionController::Base do
   end
 
   describe '.process_action' do
+    if Rails.version.to_i >= 7
+      it 'sets the controller in ActiveSupport::ExecutionContext' do
+        expect(ActiveSupport::ExecutionContext).to receive(:[]=).with(:controller, subject)
+        subject.send(:process_action, :index)
+      end
+    else
+      it 'does not set the controller in ActiveSupport::ExecutionContext' do
+        expect(ActiveSupport::ExecutionContext).not_to receive(:[]=).with(:controller, anything)
+        subject.send(:process_action, :index)
+      end
+    end
+
     it 'adds default fields to payload' do
       expect(LogStasher).to receive(:add_default_fields_to_payload).once
       expect(LogStasher).to receive(:add_default_fields_to_request_context).once


### PR DESCRIPTION
This adds missing ActiveSupport::ExecutionContext used by ActiveRecord QueryLogs
https://api.rubyonrails.org/classes/ActiveRecord/QueryLogs.html

Link to the introduction of this behaviour in Rails/ActionPack (Rails 7.0):
https://github.com/rails/rails/blob/984c3ef2775781d47efa9f541ce570daa2434a80/actionpack/lib/action_controller/metal/instrumentation.rb#L51

Before this change, having
```
# application.rb (rails app)
config.active_record.query_log_tags_enabled = true
config.active_record.query_log_tags = [ :application, :controller, :action, :job ]
```

would not yield `:controller` or `:action` when the log was being generated

Before
```
SELECT `users`.`id` FROM `users` WHERE `users`.`id` = 1
/*application=someapp*/
```

After changes in this PR:
```
SELECT `users`.`id` FROM `users` WHERE `users`.`id` = 1
/*application=someapp,action='index',controller='users'*/
```